### PR TITLE
use latest LehrFEM++

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -48,6 +48,8 @@ gcc_release/
 doc/doxygen/html
 Build/
 build/
+build_clang8/
+build_msvc/
 .idea/
 .vscode/
 venv/
@@ -57,3 +59,4 @@ cmake-build-release
 
 #OSX
 .DS_Store
+

--- a/cmake/Hunter/config.cmake
+++ b/cmake/Hunter/config.cmake
@@ -3,9 +3,9 @@ hunter_config(Eigen VERSION 3.3.5)
 
 #hunter_config(lehrfempp VERSION 0.7.20)
 hunter_config(lehrfempp
-  # Currently using commit 'rename No->Num(#157)'
-  URL "https://github.com/craffael/lehrfempp/archive/489d6da16187b44026c2c94f2592daa0dfe7170f.tar.gz"
-  SHA1 "3bd5fe8b9013f6edbb784d40fcc8c7b402fca22c"
+  # Currently using commit 'Update README.md'
+  URL "https://github.com/craffael/lehrfempp/archive/c50c2cebe1aa3eb4db0c899e8fcdb196445820f5.tar.gz"
+  SHA1 "df5748205b66a0fd74c81978b04ccd503509cfe6"
 )
 
 hunter_config(GTest VERSION 1.10.0)

--- a/developers/AvgValBoundary/mastersolution/avg_val_boundary.cc
+++ b/developers/AvgValBoundary/mastersolution/avg_val_boundary.cc
@@ -23,9 +23,9 @@ double compH1seminorm(const lf::assemble::DofHandler &dofh,
   double result = 0.;
 #if SOLUTION
   // constant identity mesh function
-  lf::uscalfe::MeshFunctionConstant mf_identity{1.};
+  lf::mesh::utils::MeshFunctionConstant mf_identity{1.};
   // constant zero mesh function
-  lf::uscalfe::MeshFunctionConstant mf_zero{0.};
+  lf::mesh::utils::MeshFunctionConstant mf_zero{0.};
 
   // compute Stiffness matrix
   // alpha := 1, beta, gamma := 0
@@ -51,7 +51,7 @@ double compH1seminorm(const lf::assemble::DofHandler &dofh,
 Eigen::VectorXd solveTestProblem(const lf::assemble::DofHandler &dofh)
 {
   // constant identity mesh function
-  lf::uscalfe::MeshFunctionConstant mf_identity{1.};
+  lf::mesh::utils::MeshFunctionConstant mf_identity{1.};
 
   // obtain Galerkin matrix for alpha = beta = gamma := 1.
   auto A = AvgValBoundary::compGalerkinMatrix(dofh, mf_identity, mf_identity,
@@ -103,13 +103,13 @@ std::vector<std::pair<unsigned int, double>> approxBoundaryFunctionalValues(
     // Obtain local->global index mapping for current finite element space
     const lf::assemble::DofHandler &dofh{fe_space->LocGlobMap()};
     const lf::base::size_type N_dofs(dofh.NumDofs());
-    lf::uscalfe::MeshFunctionConstant mf_identity{1.};
+    lf::mesh::utils::MeshFunctionConstant mf_identity{1.};
     // compute galerkin matrix
     auto A = AvgValBoundary::compGalerkinMatrix(dofh, mf_identity, mf_identity,
                                                 mf_identity);
     // compute load vector for f(x) = x.norm()
     auto f = [](Eigen::Vector2d x) -> double { return x.norm(); };
-    lf::uscalfe::MeshFunctionGlobal mf_f{f};
+    lf::mesh::utils::MeshFunctionGlobal mf_f{f};
     Eigen::Matrix<double, Eigen::Dynamic, 1> phi(N_dofs);
     phi.setZero();
     lf::uscalfe::ScalarLoadElementVectorProvider<double, decltype(mf_identity)>
@@ -123,7 +123,7 @@ std::vector<std::pair<unsigned int, double>> approxBoundaryFunctionalValues(
 
     // set up weight function
     auto w = [](Eigen::Vector2d x) -> double { return 1.; };
-    lf::uscalfe::MeshFunctionGlobal mf_w{w};
+    lf::mesh::utils::MeshFunctionGlobal mf_w{w};
     double functional_value = compBoundaryFunctional(dofh, u, mf_w);
 
     result.push_back({N_dofs, functional_value});

--- a/developers/AvgValBoundary/mastersolution/comp_gal_mat.h
+++ b/developers/AvgValBoundary/mastersolution/comp_gal_mat.h
@@ -89,7 +89,7 @@ double compBoundaryFunctional(const lf::assemble::DofHandler &dofh_lfe,
     double result = 0.;
 #if SOLUTION
     // constant zero mesh function
-    lf::uscalfe::MeshFunctionConstant mf_zero{0.};
+    lf::mesh::utils::MeshFunctionConstant mf_zero{0.};
     auto A = compGalerkinMatrix(dofh_lfe, mf_zero, mf_zero, w);
     const lf::base::size_type N_dofs(dofh_lfe.NumDofs());
     Eigen::VectorXd ones = Eigen::VectorXd::Ones(N_dofs);

--- a/developers/AvgValBoundary/mastersolution/main.cc
+++ b/developers/AvgValBoundary/mastersolution/main.cc
@@ -23,7 +23,7 @@ int main() {
   // compute H1 seminorm of the solution
   double h1s_norm = AvgValBoundary::compH1seminorm(dofh, mu);
   // constant identity mesh function
-  lf::uscalfe::MeshFunctionConstant mf_identity{1.};
+  lf::mesh::utils::MeshFunctionConstant mf_identity{1.};
   // compute boundary functional
   double boundary_functional =
       AvgValBoundary::compBoundaryFunctional(dofh, mu, mf_identity);

--- a/developers/AvgValBoundary/mastersolution/test/avgvalboundary_test.cc
+++ b/developers/AvgValBoundary/mastersolution/test/avgvalboundary_test.cc
@@ -8,7 +8,7 @@ constexpr char mesh_file[] = CURRENT_SOURCE_DIR "/../../meshes/square.msh";
 
 TEST(AvgValBoundary, TestH1SemiNorm) {
   // constant identity mesh function
-  lf::uscalfe::MeshFunctionConstant mf_identity{1.};
+  lf::mesh::utils::MeshFunctionConstant mf_identity{1.};
 
   // obtain dofh for lagrangian finite element space
   auto mesh_factory = std::make_unique<lf::mesh::hybrid2d::MeshFactory>(2);
@@ -28,7 +28,7 @@ TEST(AvgValBoundary, TestH1SemiNorm) {
 
 TEST(AvgValBoundary, TestBoundaryFunctional) {
   // constant identity mesh function
-  lf::uscalfe::MeshFunctionConstant mf_identity{1.};
+  lf::mesh::utils::MeshFunctionConstant mf_identity{1.};
 
   // obtain dofh for lagrangian finite element space
   auto mesh_factory = std::make_unique<lf::mesh::hybrid2d::MeshFactory>(2);

--- a/developers/BoundaryWave/mastersolution/BoundaryWave.cc
+++ b/developers/BoundaryWave/mastersolution/BoundaryWave.cc
@@ -34,7 +34,7 @@ lf::assemble::COOMatrix<double> buildM(
   };
   // Coefficient function used in the class template MassEdgeMatrixProvider
   auto eta =
-      lf::uscalfe::MeshFunctionGlobal([](coord_t x) -> double { return 1.0; });
+      lf::mesh::utils::MeshFunctionGlobal([](coord_t x) -> double { return 1.0; });
   lf::uscalfe::MassEdgeMatrixProvider<double, decltype(eta),
                                       decltype(edges_predicate)>
       edgemat_builder(fe_space_p, eta, edges_predicate);
@@ -65,10 +65,10 @@ lf::assemble::COOMatrix<double> buildA(
   lf::assemble::COOMatrix<double> A(N_dofs, N_dofs);
 #if SOLUTION
   // Coefficient functions used in class ReactionDiffusionElementMatrixProvider
-  auto alpha = lf::uscalfe::MeshFunctionGlobal(
+  auto alpha = lf::mesh::utils::MeshFunctionGlobal(
       [](coord_t x) -> double { return 1.0 + x.dot(x); });
   auto gamma =
-      lf::uscalfe::MeshFunctionGlobal([](coord_t x) -> double { return 0.0; });
+      lf::mesh::utils::MeshFunctionGlobal([](coord_t x) -> double { return 0.0; });
   // Initialize element matrix builder
   lf::uscalfe::ReactionDiffusionElementMatrixProvider<double, decltype(alpha),
                                                       decltype(gamma)>

--- a/developers/BoundaryWave/mastersolution/BoundaryWave.h
+++ b/developers/BoundaryWave/mastersolution/BoundaryWave.h
@@ -41,9 +41,9 @@ std::pair<Eigen::VectorXd, Eigen::VectorXd> interpolateInitialData(
 
   // Generate Lehrfem++ mesh functions out of the functors
 #if SOLUTION
-  auto mf_u0 = lf::uscalfe::MeshFunctionGlobal(
+  auto mf_u0 = lf::mesh::utils::MeshFunctionGlobal(
       [&u0](coord_t x) -> double { return u0(x); });
-  auto mf_v0 = lf::uscalfe::MeshFunctionGlobal(
+  auto mf_v0 = lf::mesh::utils::MeshFunctionGlobal(
       [&v0](coord_t x) -> double { return v0(x); });
 
   dof_vector_u0 = lf::uscalfe::NodalProjection(*fe_space_p, mf_u0);

--- a/developers/CoupledSecondOrderBVP/mastersolution/coupledsecondorderbvp.h
+++ b/developers/CoupledSecondOrderBVP/mastersolution/coupledsecondorderbvp.h
@@ -108,9 +108,9 @@ Eigen::VectorXd solveCoupledBVP(
   /* I : Creating coefficients as Lehrfem++ mesh functions */
   // Coefficients used in the class template
   // ReactionDiffusionElementMatrixProvider<SCALAR,DIFF_COEFF,REACTION_COEFF>
-  auto const_one = lf::uscalfe::MeshFunctionGlobal(
+  auto const_one = lf::mesh::utils::MeshFunctionGlobal(
       [](Eigen::Vector2d x) -> double { return 1.0; });
-  auto const_zero = lf::uscalfe::MeshFunctionGlobal(
+  auto const_zero = lf::mesh::utils::MeshFunctionGlobal(
       [](Eigen::Vector2d x) -> double { return 0.0; });
 
   /* II: Instantiating finite element matrices and right hand side vector*/
@@ -151,7 +151,7 @@ Eigen::VectorXd solveCoupledBVP(
   dropMatrixRows(bd_selector, M);
   // IV : Computing the element vector phi (associated to source f)
   // Wrap the lambda source function f in a Lehrfem++ MeshFunction
-  auto mf_f = lf::uscalfe::MeshFunctionGlobal(f);
+  auto mf_f = lf::mesh::utils::MeshFunctionGlobal(f);
   lf::uscalfe::ScalarLoadElementVectorProvider<double, decltype(mf_f)>
       elvec_builder(fe_space, mf_f);
   // Invoke assembly on cells (codim == 0)

--- a/developers/CoupledSecondOrderBVP/mastersolution/coupledsecondorderbvp_main.cc
+++ b/developers/CoupledSecondOrderBVP/mastersolution/coupledsecondorderbvp_main.cc
@@ -37,7 +37,7 @@ int main(int /*argc*/, const char** /*argv*/) {
   /* Solve the coupled boundary value problem */
   double gamma = 1.0;  // reaction coefficientS
   // Right-hand side source function f
-  auto f = lf::uscalfe::MeshFunctionGlobal(
+  auto f = lf::mesh::utils::MeshFunctionGlobal(
       [](Eigen::Vector2d x) -> double { return std::cos(x.norm()); });
   Eigen::VectorXd sol_vec = solveCoupledBVP(fe_space, gamma, f);
 

--- a/developers/CoupledSecondOrderBVP/mastersolution/test/coupledsecondorderbvp_test.cc
+++ b/developers/CoupledSecondOrderBVP/mastersolution/test/coupledsecondorderbvp_test.cc
@@ -58,9 +58,9 @@ TEST(CoupledSecondOrderBVP, dropMatrixRowsAndColumns) {
     }
   };
   // Coefficients 
-  auto const_one = lf::uscalfe::MeshFunctionGlobal(
+  auto const_one = lf::mesh::utils::MeshFunctionGlobal(
       [](Eigen::Vector2d x) -> double { return 1.0; });
-  auto const_zero = lf::uscalfe::MeshFunctionGlobal(
+  auto const_zero = lf::mesh::utils::MeshFunctionGlobal(
       [](Eigen::Vector2d x) -> double { return 0.0; });
 
   lf::assemble::COOMatrix<double> A0(N_dofs, N_dofs);
@@ -133,9 +133,9 @@ TEST(CoupledSecondOrderBVP, dropMatrixRows) {
   };
   
   // Coefficients
-  auto const_one = lf::uscalfe::MeshFunctionGlobal(
+  auto const_one = lf::mesh::utils::MeshFunctionGlobal(
       [](Eigen::Vector2d x) -> double { return 1.0; });
-  auto const_zero = lf::uscalfe::MeshFunctionGlobal(
+  auto const_zero = lf::mesh::utils::MeshFunctionGlobal(
       [](Eigen::Vector2d x) -> double { return 0.0; });
 
   lf::assemble::COOMatrix<double> M(N_dofs, N_dofs);   // off-diag blocks
@@ -191,7 +191,7 @@ TEST(CoupledSecondOrderBVP, solveCoupledBVP) {
   // reaction coefficient
   double gamma = 1.0;
   // Right-hand side source function f
-  auto f = lf::uscalfe::MeshFunctionGlobal(
+  auto f = lf::mesh::utils::MeshFunctionGlobal(
       [](Eigen::Vector2d x) -> double { return std::cos(x.norm()); });
 
   // Solution Vector 

--- a/developers/ElectrostaticForce/mastersolution/electrostaticforce.cc
+++ b/developers/ElectrostaticForce/mastersolution/electrostaticforce.cc
@@ -111,7 +111,7 @@ Eigen::VectorXd solvePoissonBVP(
   // II. IMPOSING ESSENTIAL BOUNDARY CONDITIONS
   // II.i Producing Dirichlet data
   auto mf_bd_values =
-      lf::uscalfe::MeshFunctionGlobal([](Eigen::Vector2d x) -> double {
+      lf::mesh::utils::MeshFunctionGlobal([](Eigen::Vector2d x) -> double {
         if (x.norm() < 0.27) {
           return 1.0;
         }

--- a/developers/ElectrostaticForce/mastersolution/electrostaticforce_main.cc
+++ b/developers/ElectrostaticForce/mastersolution/electrostaticforce_main.cc
@@ -35,7 +35,7 @@ int main() {
   auto uExact = [&a, &b](Eigen::VectorXd x) -> double {
     return (log((x - a).norm()) - log((x - b).norm())) / log(2) - 1;
   };
-  lf::uscalfe::MeshFunctionGlobal mf_uExact{uExact};
+  lf::mesh::utils::MeshFunctionGlobal mf_uExact{uExact};
   // Compute "exact" force using overkill quadrature
   Eigen::Vector2d exact_force = computeExactForce();
 

--- a/developers/ElementMatrixComputation/mastersolution/solve.cc
+++ b/developers/ElementMatrixComputation/mastersolution/solve.cc
@@ -22,7 +22,7 @@ namespace ElementMatrixComputation {
 /* SAM_LISTING_BEGIN_2 */
 Eigen::VectorXd solvePoissonBVP() {
   // Convert tPoissonda function f to a LehrFEM++ mesh function object
-  lf::uscalfe::MeshFunctionGlobal mf_f{f};
+  lf::mesh::utils::MeshFunctionGlobal mf_f{f};
 
   // Define the solution vector
   Eigen::VectorXd solution = Eigen::VectorXd::Zero(1);

--- a/developers/ElementMatrixComputation/mastersolution/solve.h
+++ b/developers/ElementMatrixComputation/mastersolution/solve.h
@@ -93,11 +93,11 @@ Eigen::VectorXd solve(ELMAT_BUILDER &elmat_builder,
   // Postprocessing: Compute and output norms of the finite element solution
   // Helper class for L2 error computation
   lf::uscalfe::MeshFunctionL2NormDifference lc_L2(
-      fe_space, lf::uscalfe::MeshFunctionConstant<double>(0.0), 2);
+      fe_space, lf::mesh::utils::MeshFunctionConstant<double>(0.0), 2);
   // Helper class for H1 semi norm
   lf::uscalfe::MeshFunctionL2GradientDifference lc_H1(
       fe_space,
-      lf::uscalfe::MeshFunctionConstant<Eigen::Vector2d>(
+      lf::mesh::utils::MeshFunctionConstant<Eigen::Vector2d>(
           Eigen::Vector2d(0.0, 0.0)),
       2);
 

--- a/developers/ElementMatrixComputation/mastersolution/test/elementeatrixcomputation_test.cc
+++ b/developers/ElementMatrixComputation/mastersolution/test/elementeatrixcomputation_test.cc
@@ -53,8 +53,8 @@ TEST(Solve, test) {
   const lf::assemble::DofHandler &dofh{fe_space->LocGlobMap()};
   const lf::base::size_type N_dofs(dofh.NumDofs());
 
-  lf::uscalfe::MeshFunctionGlobal mf_alpha{identityMatrixFunctor};
-  lf::uscalfe::MeshFunctionGlobal mf_gamma{identityScalarFunctor};
+  lf::mesh::utils::MeshFunctionGlobal mf_alpha{identityMatrixFunctor};
+  lf::mesh::utils::MeshFunctionGlobal mf_gamma{identityScalarFunctor};
 
   // Galerkin matrix
   lf::uscalfe::ReactionDiffusionElementMatrixProvider<
@@ -66,7 +66,7 @@ TEST(Solve, test) {
   Eigen::SparseMatrix<double> A_crs = A.makeSparse();
 
   // Right hand side
-  lf::uscalfe::MeshFunctionGlobal mf_f{ElementMatrixComputation::f};
+  lf::mesh::utils::MeshFunctionGlobal mf_f{ElementMatrixComputation::f};
 
   lf::uscalfe::LinearFELocalLoadVector<double, decltype(mf_f)> elvec_builder(
       mf_f);
@@ -91,7 +91,7 @@ TEST(Solve, test) {
 // Test SolvePoissonBVP
 //////////////////////
 TEST(SolvePoissonBVP, test) {
-  lf::uscalfe::MeshFunctionGlobal mf_f{ElementMatrixComputation::f};
+  lf::mesh::utils::MeshFunctionGlobal mf_f{ElementMatrixComputation::f};
 
   lf::uscalfe::LinearFELaplaceElementMatrix elmat_builder;
   lf::uscalfe::LinearFELocalLoadVector<double, decltype(mf_f)> elvec_builder(
@@ -120,7 +120,7 @@ TEST(MyLinearLoadVector, testTriangles)
   std::shared_ptr<lf::mesh::Mesh> mesh_p =
       lf::mesh::test_utils::GenerateHybrid2DTestMesh(0, 1.0 / 3.0);
 
-  lf::uscalfe::MeshFunctionGlobal mf_f{ElementMatrixComputation::f};
+  lf::mesh::utils::MeshFunctionGlobal mf_f{ElementMatrixComputation::f};
 
   ElementMatrixComputation::MyLinearLoadVector elvec_builder(
       ElementMatrixComputation::f);
@@ -141,7 +141,7 @@ TEST(MyLinearLoadVector, testQuads)
 {
   auto mesh_p = Generate2DTestMesh();
 
-  lf::uscalfe::MeshFunctionGlobal mf_f{ElementMatrixComputation::f};
+  lf::mesh::utils::MeshFunctionGlobal mf_f{ElementMatrixComputation::f};
 
   ElementMatrixComputation::MyLinearLoadVector elvec_builder(
       ElementMatrixComputation::f);
@@ -169,8 +169,8 @@ TEST(MyLinearFEElementMatrix, testTriangles)
       std::make_shared<lf::uscalfe::FeSpaceLagrangeO1<double>>(mesh_p);
   const lf::mesh::Mesh &mesh{*(fe_space->Mesh())};
 
-  lf::uscalfe::MeshFunctionGlobal mf_alpha{identityMatrixFunctor};
-  lf::uscalfe::MeshFunctionGlobal mf_gamma{identityScalarFunctor};
+  lf::mesh::utils::MeshFunctionGlobal mf_alpha{identityMatrixFunctor};
+  lf::mesh::utils::MeshFunctionGlobal mf_gamma{identityScalarFunctor};
 
   ElementMatrixComputation::MyLinearFEElementMatrix elmat_builder;
   lf::uscalfe::ReactionDiffusionElementMatrixProvider<
@@ -196,8 +196,8 @@ TEST(MyLinearFEElementMatrix, testQuads)
       std::make_shared<lf::uscalfe::FeSpaceLagrangeO1<double>>(mesh_p);
   const lf::mesh::Mesh &mesh{*(fe_space->Mesh())};
 
-  lf::uscalfe::MeshFunctionGlobal mf_alpha{identityMatrixFunctor};
-  lf::uscalfe::MeshFunctionGlobal mf_gamma{identityScalarFunctor};
+  lf::mesh::utils::MeshFunctionGlobal mf_alpha{identityMatrixFunctor};
+  lf::mesh::utils::MeshFunctionGlobal mf_gamma{identityScalarFunctor};
 
   ElementMatrixComputation::MyLinearFEElementMatrix elmat_builder;
   lf::uscalfe::ReactionDiffusionElementMatrixProvider<

--- a/developers/ErrorEstimatesForTraces/mastersolution/tee_lapl_robin_assembly.cc
+++ b/developers/ErrorEstimatesForTraces/mastersolution/tee_lapl_robin_assembly.cc
@@ -18,15 +18,15 @@ Eigen::VectorXd solveBVP(
   // Coefficients used in the class template
   // ReactionDiffusionElementMatrixProvider<SCALAR,DIFF_COEFF,REACTION_COEFF>
   auto alpha =
-      lf::uscalfe::MeshFunctionGlobal([](coord_t x) -> double { return 1.0; });
+      lf::mesh::utils::MeshFunctionGlobal([](coord_t x) -> double { return 1.0; });
   auto gamma =
-      lf::uscalfe::MeshFunctionGlobal([](coord_t x) -> double { return 0.0; });
+      lf::mesh::utils::MeshFunctionGlobal([](coord_t x) -> double { return 0.0; });
   // Coefficients used in the class template
   // MassEdgeMatrixProvider< SCALAR, COEFF, EDGESELECTOR >
   auto eta =
-      lf::uscalfe::MeshFunctionGlobal([](coord_t x) -> double { return 1.0; });
+      lf::mesh::utils::MeshFunctionGlobal([](coord_t x) -> double { return 1.0; });
   // Right-hand side source function f
-  auto f = lf::uscalfe::MeshFunctionGlobal(
+  auto f = lf::mesh::utils::MeshFunctionGlobal(
       [](coord_t x) -> double { return std::cos(x.norm()); });
 
   // pointer to current mesh

--- a/developers/FiniteVolumeRobin/mastersolution/test/finitevolumerobin_test.cc
+++ b/developers/FiniteVolumeRobin/mastersolution/test/finitevolumerobin_test.cc
@@ -29,7 +29,7 @@ TEST(FiniteVolumeRobin, EdgeMatrixProvider) {
   // initialize functors gamma and v
   auto gamma = [](Eigen::Vector2d x) { return 2.0; };
   auto v = [](Eigen::Vector2d x) { return 2 * x(0) + x(1); };
-  auto v_mf = lf::uscalfe::MeshFunctionGlobal(v);
+  auto v_mf = lf::mesh::utils::MeshFunctionGlobal(v);
 
   // set up finite element space and dofhandler
   auto fe_space =

--- a/developers/HandlingDOFs/mastersolution/test/handling_dofs_test.cc
+++ b/developers/HandlingDOFs/mastersolution/test/handling_dofs_test.cc
@@ -36,7 +36,7 @@ std::shared_ptr<const lf::mesh::Mesh> singleTriagMesh()
   nodesOfTria << 0, 1, 0, 0, 0, 1;
   mesh_factory_ptr->AddEntity(
       lf::base::RefEl::kTria(),
-      nonstd::span<const size_type>({0, 1, 2}),
+      std::vector<size_type>({0, 1, 2}),
       std::unique_ptr<lf::geometry::Geometry>(nullptr)); // node coords
 
   std::shared_ptr<const lf::mesh::Mesh> mesh_p = mesh_factory_ptr->Build();

--- a/developers/LinFeReactDiff/mastersolution/lin_fe_react_diff.cc
+++ b/developers/LinFeReactDiff/mastersolution/lin_fe_react_diff.cc
@@ -39,15 +39,15 @@ Eigen::VectorXd solveFE(std::shared_ptr<const lf::mesh::Mesh> mesh)
     // with Dirichlet boundary conditions fixed to 0.
     // used for the boundary conditions
     auto zero = [](Eigen::Vector2d x) -> double { return 0.; };
-    lf::uscalfe::MeshFunctionGlobal mf_zero{zero};
+    lf::mesh::utils::MeshFunctionGlobal mf_zero{zero};
 
     // used for the Galerkin Matrix
     auto identity = [](Eigen::Vector2d x) -> double { return 1.; };
-    lf::uscalfe::MeshFunctionGlobal mf_identity{identity};
+    lf::mesh::utils::MeshFunctionGlobal mf_identity{identity};
 
     // used for the load vector
     auto c = [](Eigen::Vector2d x) -> double { return x[0] * x[1]; };
-    lf::uscalfe::MeshFunctionGlobal mf_c{c};
+    lf::mesh::utils::MeshFunctionGlobal mf_c{c};
 
     auto fe_space =
         std::make_shared<lf::uscalfe::FeSpaceLagrangeO1<double>>(mesh);
@@ -125,10 +125,10 @@ double computeEnergy(std::shared_ptr<const lf::mesh::Mesh> mesh,
     const lf::base::size_type N_dofs(dofh.NumDofs());
 
     auto identity = [](Eigen::Vector2d x) -> double { return 1.; };
-    lf::uscalfe::MeshFunctionGlobal mf_identity{identity};
+    lf::mesh::utils::MeshFunctionGlobal mf_identity{identity};
 
     auto zero = [](Eigen::Vector2d x) -> double { return 0.; };
-    lf::uscalfe::MeshFunctionGlobal mf_zero{zero};
+    lf::mesh::utils::MeshFunctionGlobal mf_zero{zero};
 
     // Matrix in triplet format holding Stiffness matrix.
     lf::assemble::COOMatrix<double> Stiffness(N_dofs, N_dofs);

--- a/developers/LinFeReactDiff/mastersolution/test/lin_fe_react_diff_test.cc
+++ b/developers/LinFeReactDiff/mastersolution/test/lin_fe_react_diff_test.cc
@@ -33,11 +33,11 @@ TEST(LinFeReactDiff, TestEnergy)
 
   // Implementation from solution to not depend on the first task
   auto zero = [](Eigen::Vector2d x) -> double { return 0.; };
-  lf::uscalfe::MeshFunctionGlobal mf_zero{zero};
+  lf::mesh::utils::MeshFunctionGlobal mf_zero{zero};
   auto identity = [](Eigen::Vector2d x) -> double { return 1.; };
-  lf::uscalfe::MeshFunctionGlobal mf_identity{identity};
+  lf::mesh::utils::MeshFunctionGlobal mf_identity{identity};
   auto c = [](Eigen::Vector2d x) -> double { return x[0] * x[1]; };
-  lf::uscalfe::MeshFunctionGlobal mf_c{c};
+  lf::mesh::utils::MeshFunctionGlobal mf_c{c};
 
   auto fe_space =
       std::make_shared<lf::uscalfe::FeSpaceLagrangeO1<double>>(mesh);

--- a/developers/NonConformingCrouzeixRaviartFiniteElements/mastersolution/solve_cr_dirichlet_bvp.h
+++ b/developers/NonConformingCrouzeixRaviartFiniteElements/mastersolution/solve_cr_dirichlet_bvp.h
@@ -27,10 +27,10 @@ Eigen::VectorXd solveCRDirichletBVP(std::shared_ptr<CRFeSpace> fe_space,
     const size_type num_dofs = dof_handler.NumDofs();
 
     // Prepare coefficient and source functions as MeshFunction
-    lf::uscalfe::MeshFunctionGlobal mf_one{
+    lf::mesh::utils::MeshFunctionGlobal mf_one{
         [](Eigen::Vector2d x) -> double { return 1.; }};
-    lf::uscalfe::MeshFunctionGlobal mf_gamma{gamma};
-    lf::uscalfe::MeshFunctionGlobal mf_f{f};
+    lf::mesh::utils::MeshFunctionGlobal mf_gamma{gamma};
+    lf::mesh::utils::MeshFunctionGlobal mf_f{f};
     // Sparse Galerkin matrix in triplet format
     lf::assemble::COOMatrix<scalar_type> A(num_dofs, num_dofs);
     // Initialize ELEMENT_MATRIX_PROVIDER object

--- a/developers/NonConformingCrouzeixRaviartFiniteElements/mastersolution/solve_cr_neumann_bvp.h
+++ b/developers/NonConformingCrouzeixRaviartFiniteElements/mastersolution/solve_cr_neumann_bvp.h
@@ -27,10 +27,10 @@ Eigen::VectorXd solveCRNeumannBVP(std::shared_ptr<CRFeSpace> fe_space,
     const lf::assemble::DofHandler &dof_handler{fe_space->LocGlobMap()};
     const size_type num_dofs = dof_handler.NumDofs();
     // Prepare coefficient and source functions as MeshFunction
-    lf::uscalfe::MeshFunctionGlobal mf_one{
+    lf::mesh::utils::MeshFunctionGlobal mf_one{
         [](Eigen::Vector2d x) -> double { return 1.; }};
-    lf::uscalfe::MeshFunctionGlobal mf_gamma{gamma};
-    lf::uscalfe::MeshFunctionGlobal mf_f{f};
+    lf::mesh::utils::MeshFunctionGlobal mf_gamma{gamma};
+    lf::mesh::utils::MeshFunctionGlobal mf_f{f};
     // Sparse Galerkin matrix in triplet format
     lf::assemble::COOMatrix<scalar_type> A(num_dofs, num_dofs);
     // Initialize ELEMENT_MATRIX_PROVIDER object

--- a/developers/OutputImpedanceBVP/mastersolution/OutputImpedanceBVP.cc
+++ b/developers/OutputImpedanceBVP/mastersolution/OutputImpedanceBVP.cc
@@ -89,7 +89,7 @@ Eigen::VectorXd solveImpedanceBVP(
   // Coefficients used in the class template
   // MassEdgeMatrixProvider< SCALAR, COEFF, EDGESELECTOR >
   auto eta =
-      lf::uscalfe::MeshFunctionGlobal([](coord_t x) -> double { return 1.0; });
+      lf::mesh::utils::MeshFunctionGlobal([](coord_t x) -> double { return 1.0; });
   lf::uscalfe::MassEdgeMatrixProvider<double, decltype(eta),
                                       decltype(edges_predicate_RobinBC)>
       edgemat_builder(fe_space_p, eta, edges_predicate_RobinBC);
@@ -106,7 +106,7 @@ Eigen::VectorXd solveImpedanceBVP(
   // I.iii : Computing right-hand side vector
   // Right-hand side source function f
   auto mf_f =
-      lf::uscalfe::MeshFunctionGlobal([](coord_t x) -> double { return 0.0; });
+      lf::mesh::utils::MeshFunctionGlobal([](coord_t x) -> double { return 0.0; });
   lf::uscalfe::ScalarLoadElementVectorProvider<double, decltype(mf_f)>
       elvec_builder(fe_space_p, mf_f);
   // Invoke assembly on cells (codim == 0)
@@ -114,7 +114,7 @@ Eigen::VectorXd solveImpedanceBVP(
 
   // I.iv : Imposing essential boundary conditions
   // Dirichlet data
-  auto mf_g = lf::uscalfe::MeshFunctionGlobal(
+  auto mf_g = lf::mesh::utils::MeshFunctionGlobal(
       [&g](coord_t x) -> double { return g.dot(x); });
 #if SOLUTION
   // Inspired by the example in the documentation of

--- a/developers/OutputImpedanceBVP/mastersolution/OutputImpedanceBVP.h
+++ b/developers/OutputImpedanceBVP/mastersolution/OutputImpedanceBVP.h
@@ -42,7 +42,7 @@ Eigen::VectorXd interpolateData(
     FUNCTOR_U &&u) {
 
   // Generate Lehrfem++ mesh functions out of the functors
-  auto mf_u = lf::uscalfe::MeshFunctionGlobal(
+  auto mf_u = lf::mesh::utils::MeshFunctionGlobal(
       [&u](coord_t x) -> double { return u(x); });
 
   Eigen::VectorXd dof_vector_u = lf::uscalfe::NodalProjection(*fe_space_p, mf_u);

--- a/developers/ParametricElementMatrices/mastersolution/parametricelementmatrices_main.cc
+++ b/developers/ParametricElementMatrices/mastersolution/parametricelementmatrices_main.cc
@@ -34,7 +34,7 @@ int main() {
   /* GENERATE BVP DATA */
   // Interpolate variable coefficient function w(x) = sin(|x|)
   auto w_func = [](Eigen::Vector2d x) -> double { return std::sin(x.norm()); };
-  lf::uscalfe::MeshFunctionGlobal mf_w_func{w_func};
+  lf::mesh::utils::MeshFunctionGlobal mf_w_func{w_func};
   auto w = lf::uscalfe::NodalProjection<double>(*fe_space, mf_w_func);
   // Create direction vector entering the anisotropic diffusion tensor
   auto d = [](Eigen::Vector2d x) -> Eigen::Vector2d { return x; };

--- a/developers/ParametricElementMatrices/mastersolution/test/parametric_element_matrices_test.cc
+++ b/developers/ParametricElementMatrices/mastersolution/test/parametric_element_matrices_test.cc
@@ -31,9 +31,9 @@ TEST(ParametricElementMatrices, TestGalerkin)
     const Eigen::Vector2d d_x{d(x)};
     return Eigen::Matrix2d::Identity(2, 2) + d_x * d_x.transpose();
   };
-  lf::uscalfe::MeshFunctionGlobal mf_alpha{alpha};
+  lf::mesh::utils::MeshFunctionGlobal mf_alpha{alpha};
   auto zero = [](Eigen::Vector2d x) -> double { return 0.; };
-  lf::uscalfe::MeshFunctionGlobal mf_zero{zero};
+  lf::mesh::utils::MeshFunctionGlobal mf_zero{zero};
   // set up quadrature rule to be able to compare
   std::map<lf::base::RefEl, lf::quad::QuadRule> quad_rules{
       {lf::base::RefEl::kTria(), lf::quad::make_TriaQR_EdgeMidpointRule()},
@@ -75,12 +75,12 @@ TEST(ParametricElementMatrices, TestLoad)
   // An affine linear function that can be represented exactly
   // in the space of p.w. linear Lagrangian finite element functions
   auto w_func = [](Eigen::Vector2d x) -> double { return (3.0 * x[0] - x[1]); };
-  lf::uscalfe::MeshFunctionGlobal mf_w_func{w_func};
+  lf::mesh::utils::MeshFunctionGlobal mf_w_func{w_func};
   // function f(x) = 1/(1 + w(x)^2)
   auto f = [&w_func](Eigen::Vector2d x) -> double {
     return 1. / (1. + std::pow(w_func(x), 2));
   };
-  lf::uscalfe::MeshFunctionGlobal mf_f{f};
+  lf::mesh::utils::MeshFunctionGlobal mf_f{f};
 
   // interpolation of w on fe space: reproduces function
   auto w = lf::uscalfe::NodalProjection<double>(*fe_space, mf_w_func);

--- a/developers/ProjectionOntoGradients/mastersolution/test/projectionontogradients_test.cc
+++ b/developers/ProjectionOntoGradients/mastersolution/test/projectionontogradients_test.cc
@@ -51,7 +51,7 @@ TEST(ProjectionOntoGradients, GradProjRhsProvider_1) {
   // initialize functions f and v for which the linear form is evaluated
   auto f = [](Eigen::Vector2d x) { return Eigen::Vector2d(1.0, 2.0); };
   auto v = [](Eigen::Vector2d x) { return 2 * x(0) + x(1); };
-  auto v_mf = lf::uscalfe::MeshFunctionGlobal(v);
+  auto v_mf = lf::mesh::utils::MeshFunctionGlobal(v);
 
   // set up finite elements
   std::shared_ptr<const lf::uscalfe::UniformScalarFESpace<double>> fe_space =
@@ -81,7 +81,7 @@ TEST(ProjectionOntoGradients, GradProjRhsProvider_2) {
   // initialize functions f and v for which the linear form is evaluated
   auto f = [](Eigen::Vector2d x) { return Eigen::Vector2d(x(1), x(0)); };
   auto v = [](Eigen::Vector2d x) { return 2 * x(0) + x(1); };
-  auto v_mf = lf::uscalfe::MeshFunctionGlobal(v);
+  auto v_mf = lf::mesh::utils::MeshFunctionGlobal(v);
 
   // set up finite elements
   std::shared_ptr<const lf::uscalfe::UniformScalarFESpace<double>> fe_space =
@@ -270,7 +270,7 @@ TEST(ProjectionOntoGradients, exact_sol_test) {
   // The Function lf::uscalfe::NodalProjection requires a mesh function as its
   // second argument, so we first construct a meshFunction object which
   // describes the tent function.
-  auto tentFunction_mf = lf::uscalfe::MeshFunctionGlobal(tentFunction);
+  auto tentFunction_mf = lf::mesh::utils::MeshFunctionGlobal(tentFunction);
   auto ref_vec =
       lf::uscalfe::NodalProjection<double>(fe_space, tentFunction_mf);
 #else

--- a/developers/RegularizedNeumann/mastersolution/RegularizedNeumann_main.cc
+++ b/developers/RegularizedNeumann/mastersolution/RegularizedNeumann_main.cc
@@ -10,9 +10,9 @@
 
 int main() {
 #if SOLUTION
-  const auto f = lf::uscalfe::MeshFunctionGlobal(
+  const auto f = lf::mesh::utils::MeshFunctionGlobal(
       [](Eigen::Vector2d x) -> double { return 1.0; });
-  const auto h = lf::uscalfe::MeshFunctionGlobal(
+  const auto h = lf::mesh::utils::MeshFunctionGlobal(
       [](Eigen::Vector2d x) -> double { return 1.0; });
 
   auto mesh_p = lf::mesh::test_utils::GenerateHybrid2DTestMesh(4, 3.0);

--- a/developers/RegularizedNeumann/mastersolution/test/regularizedneumann_test.cc
+++ b/developers/RegularizedNeumann/mastersolution/test/regularizedneumann_test.cc
@@ -50,9 +50,9 @@ TEST(RegularizedNeumann, solution_test_dropDof_const) {
   std::remove("test.msh");
 
   // source and boundary functions for testing
-  const auto f = lf::uscalfe::MeshFunctionGlobal(
+  const auto f = lf::mesh::utils::MeshFunctionGlobal(
       [](Eigen::Vector2d x) -> double { return 1.0; });
-  const auto h = lf::uscalfe::MeshFunctionGlobal(
+  const auto h = lf::mesh::utils::MeshFunctionGlobal(
       [](Eigen::Vector2d x) -> double { return 1.0; });
 
   auto fe_space =
@@ -121,9 +121,9 @@ TEST(RegularizedNeumann, solution_test_dropDof_gen) {
   std::remove("test.msh");
 
   // source and boundary functions for testing
-  const auto f = lf::uscalfe::MeshFunctionGlobal(
+  const auto f = lf::mesh::utils::MeshFunctionGlobal(
       [](Eigen::Vector2d x) -> double { return x(0) + x(1); });
-  const auto h = lf::uscalfe::MeshFunctionGlobal(
+  const auto h = lf::mesh::utils::MeshFunctionGlobal(
       [](Eigen::Vector2d x) -> double { return x(0) + x(1); });
 
   auto fe_space =
@@ -192,9 +192,9 @@ TEST(RegularizedNeumann, solution_test_augment_const) {
   std::remove("test.msh");
 
   // source and boundary functions for testing
-  const auto f = lf::uscalfe::MeshFunctionGlobal(
+  const auto f = lf::mesh::utils::MeshFunctionGlobal(
       [](Eigen::Vector2d x) -> double { return 1.0; });
-  const auto h = lf::uscalfe::MeshFunctionGlobal(
+  const auto h = lf::mesh::utils::MeshFunctionGlobal(
       [](Eigen::Vector2d x) -> double { return 1.0; });
 
   auto fe_space =
@@ -266,9 +266,9 @@ TEST(RegularizedNeumann, solution_test_augment_gen) {
   std::remove("test.msh");
 
   // source and boundary functions for testing
-  const auto f = lf::uscalfe::MeshFunctionGlobal(
+  const auto f = lf::mesh::utils::MeshFunctionGlobal(
       [](Eigen::Vector2d x) -> double { return x(0) + x(1); });
-  const auto h = lf::uscalfe::MeshFunctionGlobal(
+  const auto h = lf::mesh::utils::MeshFunctionGlobal(
       [](Eigen::Vector2d x) -> double { return x(0) + x(1); });
 
   auto fe_space =

--- a/developers/SymplecticTimesteppingWaves/mastersolution/symplectictimesteppingwaves_assemble.h
+++ b/developers/SymplecticTimesteppingWaves/mastersolution/symplectictimesteppingwaves_assemble.h
@@ -48,11 +48,11 @@ Eigen::SparseMatrix<double> assembleGalerkinMatrix(
   /* Creating coefficient-functions as Lehrfem++ mesh functions */
   // Coefficient-functions used in the class template
   // ReactionDiffusionElementMatrixProvider<SCALAR,DIFF_COEFF,REACTION_COEFF>
-  auto alpha_mf = lf::uscalfe::MeshFunctionGlobal(alpha);
-  auto gamma_mf = lf::uscalfe::MeshFunctionGlobal(gamma);
+  auto alpha_mf = lf::mesh::utils::MeshFunctionGlobal(alpha);
+  auto gamma_mf = lf::mesh::utils::MeshFunctionGlobal(gamma);
   // Coefficient-function used in the class template
   // MassEdgeMatrixProvider< SCALAR, COEFF, EDGESELECTOR >
-  auto beta_mf = lf::uscalfe::MeshFunctionGlobal(beta);
+  auto beta_mf = lf::mesh::utils::MeshFunctionGlobal(beta);
 
   /* Retrieving FE data */
   // pointer to current mesh

--- a/developers/UnstableBVP/mastersolution/unstablebvp.cc
+++ b/developers/UnstableBVP/mastersolution/unstablebvp.cc
@@ -82,7 +82,7 @@ double solveTemperatureDistribution(
     return x[1] <= 0 ? 1 - x[1] : 0;
   };
   // Wrap into a MeshFunction
-  lf::uscalfe::MeshFunctionGlobal mf_bc{bc};
+  lf::mesh::utils::MeshFunctionGlobal mf_bc{bc};
 
   // We use lowest-order (p.w. linear Lagrangian finite elements), for which
   // LehrFEM++ provides a built-in description according to the paradigm of
@@ -175,7 +175,7 @@ double solveTemperatureDistribution(
   // We use this trick to avoid the manual computation and make use of the
   // LehrFEM facilities :)
   lf::uscalfe::MeshFunctionL2GradientDifference loc_comp(
-      fe_space, lf::uscalfe::MeshFunctionConstant(Eigen::Vector2d(0.0, 0.0)),
+      fe_space, lf::mesh::utils::MeshFunctionConstant(Eigen::Vector2d(0.0, 0.0)),
       2);
 
   // Compute the norm of the ``difference'' (i.e. the norm of the gradient of

--- a/developers/UnstableBVP/mastersolution/unstablebvp.cc
+++ b/developers/UnstableBVP/mastersolution/unstablebvp.cc
@@ -53,7 +53,7 @@ std::shared_ptr<lf::refinement::MeshHierarchy> createMeshHierarchy(
 
   // Initialize triangle
   mesh_factory_ptr->AddEntity(lf::base::RefEl::kTria(),
-                              nonstd::span<const lf::base::size_type>({0, 1, 2}),
+                              std::vector<lf::base::size_type>({0, 1, 2}),
                               std::unique_ptr<lf::geometry::Geometry>(nullptr));
 
   // Get a pointer to the mesh

--- a/homeworks/AvgValBoundary/mastersolution/avg_val_boundary.cc
+++ b/homeworks/AvgValBoundary/mastersolution/avg_val_boundary.cc
@@ -22,9 +22,9 @@ double compH1seminorm(const lf::assemble::DofHandler &dofh,
 {
   double result = 0.;
   // constant identity mesh function
-  lf::uscalfe::MeshFunctionConstant mf_identity{1.};
+  lf::mesh::utils::MeshFunctionConstant mf_identity{1.};
   // constant zero mesh function
-  lf::uscalfe::MeshFunctionConstant mf_zero{0.};
+  lf::mesh::utils::MeshFunctionConstant mf_zero{0.};
 
   // compute Stiffness matrix
   // alpha := 1, beta, gamma := 0
@@ -45,7 +45,7 @@ double compH1seminorm(const lf::assemble::DofHandler &dofh,
 Eigen::VectorXd solveTestProblem(const lf::assemble::DofHandler &dofh)
 {
   // constant identity mesh function
-  lf::uscalfe::MeshFunctionConstant mf_identity{1.};
+  lf::mesh::utils::MeshFunctionConstant mf_identity{1.};
 
   // obtain Galerkin matrix for alpha = beta = gamma := 1.
   auto A = AvgValBoundary::compGalerkinMatrix(dofh, mf_identity, mf_identity,
@@ -96,13 +96,13 @@ std::vector<std::pair<unsigned int, double>> approxBoundaryFunctionalValues(
     // Obtain local->global index mapping for current finite element space
     const lf::assemble::DofHandler &dofh{fe_space->LocGlobMap()};
     const lf::base::size_type N_dofs(dofh.NumDofs());
-    lf::uscalfe::MeshFunctionConstant mf_identity{1.};
+    lf::mesh::utils::MeshFunctionConstant mf_identity{1.};
     // compute galerkin matrix
     auto A = AvgValBoundary::compGalerkinMatrix(dofh, mf_identity, mf_identity,
                                                 mf_identity);
     // compute load vector for f(x) = x.norm()
     auto f = [](Eigen::Vector2d x) -> double { return x.norm(); };
-    lf::uscalfe::MeshFunctionGlobal mf_f{f};
+    lf::mesh::utils::MeshFunctionGlobal mf_f{f};
     Eigen::Matrix<double, Eigen::Dynamic, 1> phi(N_dofs);
     phi.setZero();
     lf::uscalfe::ScalarLoadElementVectorProvider<double, decltype(mf_identity)>
@@ -116,7 +116,7 @@ std::vector<std::pair<unsigned int, double>> approxBoundaryFunctionalValues(
 
     // set up weight function
     auto w = [](Eigen::Vector2d x) -> double { return 1.; };
-    lf::uscalfe::MeshFunctionGlobal mf_w{w};
+    lf::mesh::utils::MeshFunctionGlobal mf_w{w};
     double functional_value = compBoundaryFunctional(dofh, u, mf_w);
 
     result.push_back({N_dofs, functional_value});

--- a/homeworks/AvgValBoundary/mastersolution/comp_gal_mat.h
+++ b/homeworks/AvgValBoundary/mastersolution/comp_gal_mat.h
@@ -88,7 +88,7 @@ double compBoundaryFunctional(const lf::assemble::DofHandler &dofh_lfe,
 {
     double result = 0.;
     // constant zero mesh function
-    lf::uscalfe::MeshFunctionConstant mf_zero{0.};
+    lf::mesh::utils::MeshFunctionConstant mf_zero{0.};
     auto A = compGalerkinMatrix(dofh_lfe, mf_zero, mf_zero, w);
     const lf::base::size_type N_dofs(dofh_lfe.NumDofs());
     Eigen::VectorXd ones = Eigen::VectorXd::Ones(N_dofs);

--- a/homeworks/AvgValBoundary/mastersolution/main.cc
+++ b/homeworks/AvgValBoundary/mastersolution/main.cc
@@ -23,7 +23,7 @@ int main() {
   // compute H1 seminorm of the solution
   double h1s_norm = AvgValBoundary::compH1seminorm(dofh, mu);
   // constant identity mesh function
-  lf::uscalfe::MeshFunctionConstant mf_identity{1.};
+  lf::mesh::utils::MeshFunctionConstant mf_identity{1.};
   // compute boundary functional
   double boundary_functional =
       AvgValBoundary::compBoundaryFunctional(dofh, mu, mf_identity);

--- a/homeworks/AvgValBoundary/mastersolution/test/avgvalboundary_test.cc
+++ b/homeworks/AvgValBoundary/mastersolution/test/avgvalboundary_test.cc
@@ -8,7 +8,7 @@ constexpr char mesh_file[] = CURRENT_SOURCE_DIR "/../../meshes/square.msh";
 
 TEST(AvgValBoundary, TestH1SemiNorm) {
   // constant identity mesh function
-  lf::uscalfe::MeshFunctionConstant mf_identity{1.};
+  lf::mesh::utils::MeshFunctionConstant mf_identity{1.};
 
   // obtain dofh for lagrangian finite element space
   auto mesh_factory = std::make_unique<lf::mesh::hybrid2d::MeshFactory>(2);
@@ -28,7 +28,7 @@ TEST(AvgValBoundary, TestH1SemiNorm) {
 
 TEST(AvgValBoundary, TestBoundaryFunctional) {
   // constant identity mesh function
-  lf::uscalfe::MeshFunctionConstant mf_identity{1.};
+  lf::mesh::utils::MeshFunctionConstant mf_identity{1.};
 
   // obtain dofh for lagrangian finite element space
   auto mesh_factory = std::make_unique<lf::mesh::hybrid2d::MeshFactory>(2);

--- a/homeworks/AvgValBoundary/mysolution/avg_val_boundary.cc
+++ b/homeworks/AvgValBoundary/mysolution/avg_val_boundary.cc
@@ -36,7 +36,7 @@ double compH1seminorm(const lf::assemble::DofHandler &dofh,
 Eigen::VectorXd solveTestProblem(const lf::assemble::DofHandler &dofh)
 {
   // constant identity mesh function
-  lf::uscalfe::MeshFunctionConstant mf_identity{1.};
+  lf::mesh::utils::MeshFunctionConstant mf_identity{1.};
 
   // obtain Galerkin matrix for alpha = beta = gamma := 1.
   auto A = AvgValBoundary::compGalerkinMatrix(dofh, mf_identity, mf_identity,

--- a/homeworks/AvgValBoundary/mysolution/main.cc
+++ b/homeworks/AvgValBoundary/mysolution/main.cc
@@ -23,7 +23,7 @@ int main() {
   // compute H1 seminorm of the solution
   double h1s_norm = AvgValBoundary::compH1seminorm(dofh, mu);
   // constant identity mesh function
-  lf::uscalfe::MeshFunctionConstant mf_identity{1.};
+  lf::mesh::utils::MeshFunctionConstant mf_identity{1.};
   // compute boundary functional
   double boundary_functional =
       AvgValBoundary::compBoundaryFunctional(dofh, mu, mf_identity);

--- a/homeworks/AvgValBoundary/mysolution/test/avgvalboundary_test.cc
+++ b/homeworks/AvgValBoundary/mysolution/test/avgvalboundary_test.cc
@@ -8,7 +8,7 @@ constexpr char mesh_file[] = CURRENT_SOURCE_DIR "/../../meshes/square.msh";
 
 TEST(AvgValBoundary, TestH1SemiNorm) {
   // constant identity mesh function
-  lf::uscalfe::MeshFunctionConstant mf_identity{1.};
+  lf::mesh::utils::MeshFunctionConstant mf_identity{1.};
 
   // obtain dofh for lagrangian finite element space
   auto mesh_factory = std::make_unique<lf::mesh::hybrid2d::MeshFactory>(2);
@@ -28,7 +28,7 @@ TEST(AvgValBoundary, TestH1SemiNorm) {
 
 TEST(AvgValBoundary, TestBoundaryFunctional) {
   // constant identity mesh function
-  lf::uscalfe::MeshFunctionConstant mf_identity{1.};
+  lf::mesh::utils::MeshFunctionConstant mf_identity{1.};
 
   // obtain dofh for lagrangian finite element space
   auto mesh_factory = std::make_unique<lf::mesh::hybrid2d::MeshFactory>(2);

--- a/homeworks/AvgValBoundary/templates/avg_val_boundary.cc
+++ b/homeworks/AvgValBoundary/templates/avg_val_boundary.cc
@@ -36,7 +36,7 @@ double compH1seminorm(const lf::assemble::DofHandler &dofh,
 Eigen::VectorXd solveTestProblem(const lf::assemble::DofHandler &dofh)
 {
   // constant identity mesh function
-  lf::uscalfe::MeshFunctionConstant mf_identity{1.};
+  lf::mesh::utils::MeshFunctionConstant mf_identity{1.};
 
   // obtain Galerkin matrix for alpha = beta = gamma := 1.
   auto A = AvgValBoundary::compGalerkinMatrix(dofh, mf_identity, mf_identity,

--- a/homeworks/AvgValBoundary/templates/main.cc
+++ b/homeworks/AvgValBoundary/templates/main.cc
@@ -23,7 +23,7 @@ int main() {
   // compute H1 seminorm of the solution
   double h1s_norm = AvgValBoundary::compH1seminorm(dofh, mu);
   // constant identity mesh function
-  lf::uscalfe::MeshFunctionConstant mf_identity{1.};
+  lf::mesh::utils::MeshFunctionConstant mf_identity{1.};
   // compute boundary functional
   double boundary_functional =
       AvgValBoundary::compBoundaryFunctional(dofh, mu, mf_identity);

--- a/homeworks/AvgValBoundary/templates/test/avgvalboundary_test.cc
+++ b/homeworks/AvgValBoundary/templates/test/avgvalboundary_test.cc
@@ -8,7 +8,7 @@ constexpr char mesh_file[] = CURRENT_SOURCE_DIR "/../../meshes/square.msh";
 
 TEST(AvgValBoundary, TestH1SemiNorm) {
   // constant identity mesh function
-  lf::uscalfe::MeshFunctionConstant mf_identity{1.};
+  lf::mesh::utils::MeshFunctionConstant mf_identity{1.};
 
   // obtain dofh for lagrangian finite element space
   auto mesh_factory = std::make_unique<lf::mesh::hybrid2d::MeshFactory>(2);
@@ -28,7 +28,7 @@ TEST(AvgValBoundary, TestH1SemiNorm) {
 
 TEST(AvgValBoundary, TestBoundaryFunctional) {
   // constant identity mesh function
-  lf::uscalfe::MeshFunctionConstant mf_identity{1.};
+  lf::mesh::utils::MeshFunctionConstant mf_identity{1.};
 
   // obtain dofh for lagrangian finite element space
   auto mesh_factory = std::make_unique<lf::mesh::hybrid2d::MeshFactory>(2);

--- a/homeworks/BoundaryWave/mastersolution/BoundaryWave.cc
+++ b/homeworks/BoundaryWave/mastersolution/BoundaryWave.cc
@@ -33,7 +33,7 @@ lf::assemble::COOMatrix<double> buildM(
   };
   // Coefficient function used in the class template MassEdgeMatrixProvider
   auto eta =
-      lf::uscalfe::MeshFunctionGlobal([](coord_t x) -> double { return 1.0; });
+      lf::mesh::utils::MeshFunctionGlobal([](coord_t x) -> double { return 1.0; });
   lf::uscalfe::MassEdgeMatrixProvider<double, decltype(eta),
                                       decltype(edges_predicate)>
       edgemat_builder(fe_space_p, eta, edges_predicate);
@@ -58,10 +58,10 @@ lf::assemble::COOMatrix<double> buildA(
   // Matrix in triplet format holding Galerkin matrix, zero initially.
   lf::assemble::COOMatrix<double> A(N_dofs, N_dofs);
   // Coefficient functions used in class ReactionDiffusionElementMatrixProvider
-  auto alpha = lf::uscalfe::MeshFunctionGlobal(
+  auto alpha = lf::mesh::utils::MeshFunctionGlobal(
       [](coord_t x) -> double { return 1.0 + x.dot(x); });
   auto gamma =
-      lf::uscalfe::MeshFunctionGlobal([](coord_t x) -> double { return 0.0; });
+      lf::mesh::utils::MeshFunctionGlobal([](coord_t x) -> double { return 0.0; });
   // Initialize element matrix builder
   lf::uscalfe::ReactionDiffusionElementMatrixProvider<double, decltype(alpha),
                                                       decltype(gamma)>

--- a/homeworks/BoundaryWave/mastersolution/BoundaryWave.h
+++ b/homeworks/BoundaryWave/mastersolution/BoundaryWave.h
@@ -40,9 +40,9 @@ std::pair<Eigen::VectorXd, Eigen::VectorXd> interpolateInitialData(
   Eigen::VectorXd dof_vector_u0, dof_vector_v0;
 
   // Generate Lehrfem++ mesh functions out of the functors
-  auto mf_u0 = lf::uscalfe::MeshFunctionGlobal(
+  auto mf_u0 = lf::mesh::utils::MeshFunctionGlobal(
       [&u0](coord_t x) -> double { return u0(x); });
-  auto mf_v0 = lf::uscalfe::MeshFunctionGlobal(
+  auto mf_v0 = lf::mesh::utils::MeshFunctionGlobal(
       [&v0](coord_t x) -> double { return v0(x); });
 
   dof_vector_u0 = lf::uscalfe::NodalProjection(*fe_space_p, mf_u0);

--- a/homeworks/CoupledSecondOrderBVP/mastersolution/coupledsecondorderbvp.h
+++ b/homeworks/CoupledSecondOrderBVP/mastersolution/coupledsecondorderbvp.h
@@ -108,9 +108,9 @@ Eigen::VectorXd solveCoupledBVP(
   /* I : Creating coefficients as Lehrfem++ mesh functions */
   // Coefficients used in the class template
   // ReactionDiffusionElementMatrixProvider<SCALAR,DIFF_COEFF,REACTION_COEFF>
-  auto const_one = lf::uscalfe::MeshFunctionGlobal(
+  auto const_one = lf::mesh::utils::MeshFunctionGlobal(
       [](Eigen::Vector2d x) -> double { return 1.0; });
-  auto const_zero = lf::uscalfe::MeshFunctionGlobal(
+  auto const_zero = lf::mesh::utils::MeshFunctionGlobal(
       [](Eigen::Vector2d x) -> double { return 0.0; });
 
   /* II: Instantiating finite element matrices and right hand side vector*/
@@ -151,7 +151,7 @@ Eigen::VectorXd solveCoupledBVP(
   dropMatrixRows(bd_selector, M);
   // IV : Computing the element vector phi (associated to source f)
   // Wrap the lambda source function f in a Lehrfem++ MeshFunction
-  auto mf_f = lf::uscalfe::MeshFunctionGlobal(f);
+  auto mf_f = lf::mesh::utils::MeshFunctionGlobal(f);
   lf::uscalfe::ScalarLoadElementVectorProvider<double, decltype(mf_f)>
       elvec_builder(fe_space, mf_f);
   // Invoke assembly on cells (codim == 0)

--- a/homeworks/CoupledSecondOrderBVP/mastersolution/coupledsecondorderbvp_main.cc
+++ b/homeworks/CoupledSecondOrderBVP/mastersolution/coupledsecondorderbvp_main.cc
@@ -37,7 +37,7 @@ int main(int /*argc*/, const char** /*argv*/) {
   /* Solve the coupled boundary value problem */
   double gamma = 1.0;  // reaction coefficientS
   // Right-hand side source function f
-  auto f = lf::uscalfe::MeshFunctionGlobal(
+  auto f = lf::mesh::utils::MeshFunctionGlobal(
       [](Eigen::Vector2d x) -> double { return std::cos(x.norm()); });
   Eigen::VectorXd sol_vec = solveCoupledBVP(fe_space, gamma, f);
 

--- a/homeworks/CoupledSecondOrderBVP/mastersolution/test/coupledsecondorderbvp_test.cc
+++ b/homeworks/CoupledSecondOrderBVP/mastersolution/test/coupledsecondorderbvp_test.cc
@@ -58,9 +58,9 @@ TEST(CoupledSecondOrderBVP, dropMatrixRowsAndColumns) {
     }
   };
   // Coefficients 
-  auto const_one = lf::uscalfe::MeshFunctionGlobal(
+  auto const_one = lf::mesh::utils::MeshFunctionGlobal(
       [](Eigen::Vector2d x) -> double { return 1.0; });
-  auto const_zero = lf::uscalfe::MeshFunctionGlobal(
+  auto const_zero = lf::mesh::utils::MeshFunctionGlobal(
       [](Eigen::Vector2d x) -> double { return 0.0; });
 
   lf::assemble::COOMatrix<double> A0(N_dofs, N_dofs);
@@ -133,9 +133,9 @@ TEST(CoupledSecondOrderBVP, dropMatrixRows) {
   };
   
   // Coefficients
-  auto const_one = lf::uscalfe::MeshFunctionGlobal(
+  auto const_one = lf::mesh::utils::MeshFunctionGlobal(
       [](Eigen::Vector2d x) -> double { return 1.0; });
-  auto const_zero = lf::uscalfe::MeshFunctionGlobal(
+  auto const_zero = lf::mesh::utils::MeshFunctionGlobal(
       [](Eigen::Vector2d x) -> double { return 0.0; });
 
   lf::assemble::COOMatrix<double> M(N_dofs, N_dofs);   // off-diag blocks
@@ -191,7 +191,7 @@ TEST(CoupledSecondOrderBVP, solveCoupledBVP) {
   // reaction coefficient
   double gamma = 1.0;
   // Right-hand side source function f
-  auto f = lf::uscalfe::MeshFunctionGlobal(
+  auto f = lf::mesh::utils::MeshFunctionGlobal(
       [](Eigen::Vector2d x) -> double { return std::cos(x.norm()); });
 
   // Solution Vector 

--- a/homeworks/CoupledSecondOrderBVP/mysolution/coupledsecondorderbvp.h
+++ b/homeworks/CoupledSecondOrderBVP/mysolution/coupledsecondorderbvp.h
@@ -108,9 +108,9 @@ Eigen::VectorXd solveCoupledBVP(
   /* I : Creating coefficients as Lehrfem++ mesh functions */
   // Coefficients used in the class template
   // ReactionDiffusionElementMatrixProvider<SCALAR,DIFF_COEFF,REACTION_COEFF>
-  auto const_one = lf::uscalfe::MeshFunctionGlobal(
+  auto const_one = lf::mesh::utils::MeshFunctionGlobal(
       [](Eigen::Vector2d x) -> double { return 1.0; });
-  auto const_zero = lf::uscalfe::MeshFunctionGlobal(
+  auto const_zero = lf::mesh::utils::MeshFunctionGlobal(
       [](Eigen::Vector2d x) -> double { return 0.0; });
 
   /* II: Instantiating finite element matrices and right hand side vector*/
@@ -151,7 +151,7 @@ Eigen::VectorXd solveCoupledBVP(
   dropMatrixRows(bd_selector, M);
   // IV : Computing the element vector phi (associated to source f)
   // Wrap the lambda source function f in a Lehrfem++ MeshFunction
-  auto mf_f = lf::uscalfe::MeshFunctionGlobal(f);
+  auto mf_f = lf::mesh::utils::MeshFunctionGlobal(f);
   lf::uscalfe::ScalarLoadElementVectorProvider<double, decltype(mf_f)>
       elvec_builder(fe_space, mf_f);
   // Invoke assembly on cells (codim == 0)

--- a/homeworks/CoupledSecondOrderBVP/mysolution/coupledsecondorderbvp_main.cc
+++ b/homeworks/CoupledSecondOrderBVP/mysolution/coupledsecondorderbvp_main.cc
@@ -37,7 +37,7 @@ int main(int /*argc*/, const char** /*argv*/) {
   /* Solve the coupled boundary value problem */
   double gamma = 1.0;  // reaction coefficientS
   // Right-hand side source function f
-  auto f = lf::uscalfe::MeshFunctionGlobal(
+  auto f = lf::mesh::utils::MeshFunctionGlobal(
       [](Eigen::Vector2d x) -> double { return std::cos(x.norm()); });
   Eigen::VectorXd sol_vec = solveCoupledBVP(fe_space, gamma, f);
 

--- a/homeworks/CoupledSecondOrderBVP/mysolution/test/coupledsecondorderbvp_test.cc
+++ b/homeworks/CoupledSecondOrderBVP/mysolution/test/coupledsecondorderbvp_test.cc
@@ -58,9 +58,9 @@ TEST(CoupledSecondOrderBVP, dropMatrixRowsAndColumns) {
     }
   };
   // Coefficients 
-  auto const_one = lf::uscalfe::MeshFunctionGlobal(
+  auto const_one = lf::mesh::utils::MeshFunctionGlobal(
       [](Eigen::Vector2d x) -> double { return 1.0; });
-  auto const_zero = lf::uscalfe::MeshFunctionGlobal(
+  auto const_zero = lf::mesh::utils::MeshFunctionGlobal(
       [](Eigen::Vector2d x) -> double { return 0.0; });
 
   lf::assemble::COOMatrix<double> A0(N_dofs, N_dofs);
@@ -133,9 +133,9 @@ TEST(CoupledSecondOrderBVP, dropMatrixRows) {
   };
   
   // Coefficients
-  auto const_one = lf::uscalfe::MeshFunctionGlobal(
+  auto const_one = lf::mesh::utils::MeshFunctionGlobal(
       [](Eigen::Vector2d x) -> double { return 1.0; });
-  auto const_zero = lf::uscalfe::MeshFunctionGlobal(
+  auto const_zero = lf::mesh::utils::MeshFunctionGlobal(
       [](Eigen::Vector2d x) -> double { return 0.0; });
 
   lf::assemble::COOMatrix<double> M(N_dofs, N_dofs);   // off-diag blocks
@@ -191,7 +191,7 @@ TEST(CoupledSecondOrderBVP, solveCoupledBVP) {
   // reaction coefficient
   double gamma = 1.0;
   // Right-hand side source function f
-  auto f = lf::uscalfe::MeshFunctionGlobal(
+  auto f = lf::mesh::utils::MeshFunctionGlobal(
       [](Eigen::Vector2d x) -> double { return std::cos(x.norm()); });
 
   // Solution Vector 

--- a/homeworks/CoupledSecondOrderBVP/templates/coupledsecondorderbvp.h
+++ b/homeworks/CoupledSecondOrderBVP/templates/coupledsecondorderbvp.h
@@ -108,9 +108,9 @@ Eigen::VectorXd solveCoupledBVP(
   /* I : Creating coefficients as Lehrfem++ mesh functions */
   // Coefficients used in the class template
   // ReactionDiffusionElementMatrixProvider<SCALAR,DIFF_COEFF,REACTION_COEFF>
-  auto const_one = lf::uscalfe::MeshFunctionGlobal(
+  auto const_one = lf::mesh::utils::MeshFunctionGlobal(
       [](Eigen::Vector2d x) -> double { return 1.0; });
-  auto const_zero = lf::uscalfe::MeshFunctionGlobal(
+  auto const_zero = lf::mesh::utils::MeshFunctionGlobal(
       [](Eigen::Vector2d x) -> double { return 0.0; });
 
   /* II: Instantiating finite element matrices and right hand side vector*/
@@ -151,7 +151,7 @@ Eigen::VectorXd solveCoupledBVP(
   dropMatrixRows(bd_selector, M);
   // IV : Computing the element vector phi (associated to source f)
   // Wrap the lambda source function f in a Lehrfem++ MeshFunction
-  auto mf_f = lf::uscalfe::MeshFunctionGlobal(f);
+  auto mf_f = lf::mesh::utils::MeshFunctionGlobal(f);
   lf::uscalfe::ScalarLoadElementVectorProvider<double, decltype(mf_f)>
       elvec_builder(fe_space, mf_f);
   // Invoke assembly on cells (codim == 0)

--- a/homeworks/CoupledSecondOrderBVP/templates/coupledsecondorderbvp_main.cc
+++ b/homeworks/CoupledSecondOrderBVP/templates/coupledsecondorderbvp_main.cc
@@ -37,7 +37,7 @@ int main(int /*argc*/, const char** /*argv*/) {
   /* Solve the coupled boundary value problem */
   double gamma = 1.0;  // reaction coefficientS
   // Right-hand side source function f
-  auto f = lf::uscalfe::MeshFunctionGlobal(
+  auto f = lf::mesh::utils::MeshFunctionGlobal(
       [](Eigen::Vector2d x) -> double { return std::cos(x.norm()); });
   Eigen::VectorXd sol_vec = solveCoupledBVP(fe_space, gamma, f);
 

--- a/homeworks/CoupledSecondOrderBVP/templates/test/coupledsecondorderbvp_test.cc
+++ b/homeworks/CoupledSecondOrderBVP/templates/test/coupledsecondorderbvp_test.cc
@@ -58,9 +58,9 @@ TEST(CoupledSecondOrderBVP, dropMatrixRowsAndColumns) {
     }
   };
   // Coefficients 
-  auto const_one = lf::uscalfe::MeshFunctionGlobal(
+  auto const_one = lf::mesh::utils::MeshFunctionGlobal(
       [](Eigen::Vector2d x) -> double { return 1.0; });
-  auto const_zero = lf::uscalfe::MeshFunctionGlobal(
+  auto const_zero = lf::mesh::utils::MeshFunctionGlobal(
       [](Eigen::Vector2d x) -> double { return 0.0; });
 
   lf::assemble::COOMatrix<double> A0(N_dofs, N_dofs);
@@ -133,9 +133,9 @@ TEST(CoupledSecondOrderBVP, dropMatrixRows) {
   };
   
   // Coefficients
-  auto const_one = lf::uscalfe::MeshFunctionGlobal(
+  auto const_one = lf::mesh::utils::MeshFunctionGlobal(
       [](Eigen::Vector2d x) -> double { return 1.0; });
-  auto const_zero = lf::uscalfe::MeshFunctionGlobal(
+  auto const_zero = lf::mesh::utils::MeshFunctionGlobal(
       [](Eigen::Vector2d x) -> double { return 0.0; });
 
   lf::assemble::COOMatrix<double> M(N_dofs, N_dofs);   // off-diag blocks
@@ -191,7 +191,7 @@ TEST(CoupledSecondOrderBVP, solveCoupledBVP) {
   // reaction coefficient
   double gamma = 1.0;
   // Right-hand side source function f
-  auto f = lf::uscalfe::MeshFunctionGlobal(
+  auto f = lf::mesh::utils::MeshFunctionGlobal(
       [](Eigen::Vector2d x) -> double { return std::cos(x.norm()); });
 
   // Solution Vector 

--- a/homeworks/ElectrostaticForce/mastersolution/electrostaticforce.cc
+++ b/homeworks/ElectrostaticForce/mastersolution/electrostaticforce.cc
@@ -111,7 +111,7 @@ Eigen::VectorXd solvePoissonBVP(
   // II. IMPOSING ESSENTIAL BOUNDARY CONDITIONS
   // II.i Producing Dirichlet data
   auto mf_bd_values =
-      lf::uscalfe::MeshFunctionGlobal([](Eigen::Vector2d x) -> double {
+      lf::mesh::utils::MeshFunctionGlobal([](Eigen::Vector2d x) -> double {
         if (x.norm() < 0.27) {
           return 1.0;
         }

--- a/homeworks/ElectrostaticForce/mastersolution/electrostaticforce_main.cc
+++ b/homeworks/ElectrostaticForce/mastersolution/electrostaticforce_main.cc
@@ -35,7 +35,7 @@ int main() {
   auto uExact = [&a, &b](Eigen::VectorXd x) -> double {
     return (log((x - a).norm()) - log((x - b).norm())) / log(2) - 1;
   };
-  lf::uscalfe::MeshFunctionGlobal mf_uExact{uExact};
+  lf::mesh::utils::MeshFunctionGlobal mf_uExact{uExact};
   // Compute "exact" force using overkill quadrature
   Eigen::Vector2d exact_force = computeExactForce();
 

--- a/homeworks/ElectrostaticForce/mysolution/electrostaticforce.cc
+++ b/homeworks/ElectrostaticForce/mysolution/electrostaticforce.cc
@@ -111,7 +111,7 @@ Eigen::VectorXd solvePoissonBVP(
   // II. IMPOSING ESSENTIAL BOUNDARY CONDITIONS
   // II.i Producing Dirichlet data
   auto mf_bd_values =
-      lf::uscalfe::MeshFunctionGlobal([](Eigen::Vector2d x) -> double {
+      lf::mesh::utils::MeshFunctionGlobal([](Eigen::Vector2d x) -> double {
         if (x.norm() < 0.27) {
           return 1.0;
         }

--- a/homeworks/ElectrostaticForce/mysolution/electrostaticforce_main.cc
+++ b/homeworks/ElectrostaticForce/mysolution/electrostaticforce_main.cc
@@ -35,7 +35,7 @@ int main() {
   auto uExact = [&a, &b](Eigen::VectorXd x) -> double {
     return (log((x - a).norm()) - log((x - b).norm())) / log(2) - 1;
   };
-  lf::uscalfe::MeshFunctionGlobal mf_uExact{uExact};
+  lf::mesh::utils::MeshFunctionGlobal mf_uExact{uExact};
   // Compute "exact" force using overkill quadrature
   Eigen::Vector2d exact_force = computeExactForce();
 

--- a/homeworks/ElectrostaticForce/templates/electrostaticforce.cc
+++ b/homeworks/ElectrostaticForce/templates/electrostaticforce.cc
@@ -111,7 +111,7 @@ Eigen::VectorXd solvePoissonBVP(
   // II. IMPOSING ESSENTIAL BOUNDARY CONDITIONS
   // II.i Producing Dirichlet data
   auto mf_bd_values =
-      lf::uscalfe::MeshFunctionGlobal([](Eigen::Vector2d x) -> double {
+      lf::mesh::utils::MeshFunctionGlobal([](Eigen::Vector2d x) -> double {
         if (x.norm() < 0.27) {
           return 1.0;
         }

--- a/homeworks/ElectrostaticForce/templates/electrostaticforce_main.cc
+++ b/homeworks/ElectrostaticForce/templates/electrostaticforce_main.cc
@@ -35,7 +35,7 @@ int main() {
   auto uExact = [&a, &b](Eigen::VectorXd x) -> double {
     return (log((x - a).norm()) - log((x - b).norm())) / log(2) - 1;
   };
-  lf::uscalfe::MeshFunctionGlobal mf_uExact{uExact};
+  lf::mesh::utils::MeshFunctionGlobal mf_uExact{uExact};
   // Compute "exact" force using overkill quadrature
   Eigen::Vector2d exact_force = computeExactForce();
 

--- a/homeworks/ElementMatrixComputation/mastersolution/solve.cc
+++ b/homeworks/ElementMatrixComputation/mastersolution/solve.cc
@@ -22,7 +22,7 @@ namespace ElementMatrixComputation {
 /* SAM_LISTING_BEGIN_2 */
 Eigen::VectorXd solvePoissonBVP() {
   // Convert tPoissonda function f to a LehrFEM++ mesh function object
-  lf::uscalfe::MeshFunctionGlobal mf_f{f};
+  lf::mesh::utils::MeshFunctionGlobal mf_f{f};
 
   // Define the solution vector
   Eigen::VectorXd solution = Eigen::VectorXd::Zero(1);

--- a/homeworks/ElementMatrixComputation/mastersolution/solve.h
+++ b/homeworks/ElementMatrixComputation/mastersolution/solve.h
@@ -87,11 +87,11 @@ Eigen::VectorXd solve(ELMAT_BUILDER &elmat_builder,
   // Postprocessing: Compute and output norms of the finite element solution
   // Helper class for L2 error computation
   lf::uscalfe::MeshFunctionL2NormDifference lc_L2(
-      fe_space, lf::uscalfe::MeshFunctionConstant<double>(0.0), 2);
+      fe_space, lf::mesh::utils::MeshFunctionConstant<double>(0.0), 2);
   // Helper class for H1 semi norm
   lf::uscalfe::MeshFunctionL2GradientDifference lc_H1(
       fe_space,
-      lf::uscalfe::MeshFunctionConstant<Eigen::Vector2d>(
+      lf::mesh::utils::MeshFunctionConstant<Eigen::Vector2d>(
           Eigen::Vector2d(0.0, 0.0)),
       2);
 

--- a/homeworks/ElementMatrixComputation/mastersolution/test/elementeatrixcomputation_test.cc
+++ b/homeworks/ElementMatrixComputation/mastersolution/test/elementeatrixcomputation_test.cc
@@ -53,8 +53,8 @@ TEST(Solve, test) {
   const lf::assemble::DofHandler &dofh{fe_space->LocGlobMap()};
   const lf::base::size_type N_dofs(dofh.NumDofs());
 
-  lf::uscalfe::MeshFunctionGlobal mf_alpha{identityMatrixFunctor};
-  lf::uscalfe::MeshFunctionGlobal mf_gamma{identityScalarFunctor};
+  lf::mesh::utils::MeshFunctionGlobal mf_alpha{identityMatrixFunctor};
+  lf::mesh::utils::MeshFunctionGlobal mf_gamma{identityScalarFunctor};
 
   // Galerkin matrix
   lf::uscalfe::ReactionDiffusionElementMatrixProvider<
@@ -66,7 +66,7 @@ TEST(Solve, test) {
   Eigen::SparseMatrix<double> A_crs = A.makeSparse();
 
   // Right hand side
-  lf::uscalfe::MeshFunctionGlobal mf_f{ElementMatrixComputation::f};
+  lf::mesh::utils::MeshFunctionGlobal mf_f{ElementMatrixComputation::f};
 
   lf::uscalfe::LinearFELocalLoadVector<double, decltype(mf_f)> elvec_builder(
       mf_f);
@@ -91,7 +91,7 @@ TEST(Solve, test) {
 // Test SolvePoissonBVP
 //////////////////////
 TEST(SolvePoissonBVP, test) {
-  lf::uscalfe::MeshFunctionGlobal mf_f{ElementMatrixComputation::f};
+  lf::mesh::utils::MeshFunctionGlobal mf_f{ElementMatrixComputation::f};
 
   lf::uscalfe::LinearFELaplaceElementMatrix elmat_builder;
   lf::uscalfe::LinearFELocalLoadVector<double, decltype(mf_f)> elvec_builder(
@@ -120,7 +120,7 @@ TEST(MyLinearLoadVector, testTriangles)
   std::shared_ptr<lf::mesh::Mesh> mesh_p =
       lf::mesh::test_utils::GenerateHybrid2DTestMesh(0, 1.0 / 3.0);
 
-  lf::uscalfe::MeshFunctionGlobal mf_f{ElementMatrixComputation::f};
+  lf::mesh::utils::MeshFunctionGlobal mf_f{ElementMatrixComputation::f};
 
   ElementMatrixComputation::MyLinearLoadVector elvec_builder(
       ElementMatrixComputation::f);
@@ -141,7 +141,7 @@ TEST(MyLinearLoadVector, testQuads)
 {
   auto mesh_p = Generate2DTestMesh();
 
-  lf::uscalfe::MeshFunctionGlobal mf_f{ElementMatrixComputation::f};
+  lf::mesh::utils::MeshFunctionGlobal mf_f{ElementMatrixComputation::f};
 
   ElementMatrixComputation::MyLinearLoadVector elvec_builder(
       ElementMatrixComputation::f);
@@ -169,8 +169,8 @@ TEST(MyLinearFEElementMatrix, testTriangles)
       std::make_shared<lf::uscalfe::FeSpaceLagrangeO1<double>>(mesh_p);
   const lf::mesh::Mesh &mesh{*(fe_space->Mesh())};
 
-  lf::uscalfe::MeshFunctionGlobal mf_alpha{identityMatrixFunctor};
-  lf::uscalfe::MeshFunctionGlobal mf_gamma{identityScalarFunctor};
+  lf::mesh::utils::MeshFunctionGlobal mf_alpha{identityMatrixFunctor};
+  lf::mesh::utils::MeshFunctionGlobal mf_gamma{identityScalarFunctor};
 
   ElementMatrixComputation::MyLinearFEElementMatrix elmat_builder;
   lf::uscalfe::ReactionDiffusionElementMatrixProvider<
@@ -196,8 +196,8 @@ TEST(MyLinearFEElementMatrix, testQuads)
       std::make_shared<lf::uscalfe::FeSpaceLagrangeO1<double>>(mesh_p);
   const lf::mesh::Mesh &mesh{*(fe_space->Mesh())};
 
-  lf::uscalfe::MeshFunctionGlobal mf_alpha{identityMatrixFunctor};
-  lf::uscalfe::MeshFunctionGlobal mf_gamma{identityScalarFunctor};
+  lf::mesh::utils::MeshFunctionGlobal mf_alpha{identityMatrixFunctor};
+  lf::mesh::utils::MeshFunctionGlobal mf_gamma{identityScalarFunctor};
 
   ElementMatrixComputation::MyLinearFEElementMatrix elmat_builder;
   lf::uscalfe::ReactionDiffusionElementMatrixProvider<

--- a/homeworks/ElementMatrixComputation/mysolution/solve.cc
+++ b/homeworks/ElementMatrixComputation/mysolution/solve.cc
@@ -22,7 +22,7 @@ namespace ElementMatrixComputation {
 /* SAM_LISTING_BEGIN_2 */
 Eigen::VectorXd solvePoissonBVP() {
   // Convert tPoissonda function f to a LehrFEM++ mesh function object
-  lf::uscalfe::MeshFunctionGlobal mf_f{f};
+  lf::mesh::utils::MeshFunctionGlobal mf_f{f};
 
   // Define the solution vector
   Eigen::VectorXd solution = Eigen::VectorXd::Zero(1);

--- a/homeworks/ElementMatrixComputation/mysolution/solve.h
+++ b/homeworks/ElementMatrixComputation/mysolution/solve.h
@@ -83,11 +83,11 @@ Eigen::VectorXd solve(ELMAT_BUILDER &elmat_builder,
   // Postprocessing: Compute and output norms of the finite element solution
   // Helper class for L2 error computation
   lf::uscalfe::MeshFunctionL2NormDifference lc_L2(
-      fe_space, lf::uscalfe::MeshFunctionConstant<double>(0.0), 2);
+      fe_space, lf::mesh::utils::MeshFunctionConstant<double>(0.0), 2);
   // Helper class for H1 semi norm
   lf::uscalfe::MeshFunctionL2GradientDifference lc_H1(
       fe_space,
-      lf::uscalfe::MeshFunctionConstant<Eigen::Vector2d>(
+      lf::mesh::utils::MeshFunctionConstant<Eigen::Vector2d>(
           Eigen::Vector2d(0.0, 0.0)),
       2);
 

--- a/homeworks/ElementMatrixComputation/mysolution/test/elementeatrixcomputation_test.cc
+++ b/homeworks/ElementMatrixComputation/mysolution/test/elementeatrixcomputation_test.cc
@@ -53,8 +53,8 @@ TEST(Solve, test) {
   const lf::assemble::DofHandler &dofh{fe_space->LocGlobMap()};
   const lf::base::size_type N_dofs(dofh.NumDofs());
 
-  lf::uscalfe::MeshFunctionGlobal mf_alpha{identityMatrixFunctor};
-  lf::uscalfe::MeshFunctionGlobal mf_gamma{identityScalarFunctor};
+  lf::mesh::utils::MeshFunctionGlobal mf_alpha{identityMatrixFunctor};
+  lf::mesh::utils::MeshFunctionGlobal mf_gamma{identityScalarFunctor};
 
   // Galerkin matrix
   lf::uscalfe::ReactionDiffusionElementMatrixProvider<
@@ -66,7 +66,7 @@ TEST(Solve, test) {
   Eigen::SparseMatrix<double> A_crs = A.makeSparse();
 
   // Right hand side
-  lf::uscalfe::MeshFunctionGlobal mf_f{ElementMatrixComputation::f};
+  lf::mesh::utils::MeshFunctionGlobal mf_f{ElementMatrixComputation::f};
 
   lf::uscalfe::LinearFELocalLoadVector<double, decltype(mf_f)> elvec_builder(
       mf_f);
@@ -91,7 +91,7 @@ TEST(Solve, test) {
 // Test SolvePoissonBVP
 //////////////////////
 TEST(SolvePoissonBVP, test) {
-  lf::uscalfe::MeshFunctionGlobal mf_f{ElementMatrixComputation::f};
+  lf::mesh::utils::MeshFunctionGlobal mf_f{ElementMatrixComputation::f};
 
   lf::uscalfe::LinearFELaplaceElementMatrix elmat_builder;
   lf::uscalfe::LinearFELocalLoadVector<double, decltype(mf_f)> elvec_builder(
@@ -120,7 +120,7 @@ TEST(MyLinearLoadVector, testTriangles)
   std::shared_ptr<lf::mesh::Mesh> mesh_p =
       lf::mesh::test_utils::GenerateHybrid2DTestMesh(0, 1.0 / 3.0);
 
-  lf::uscalfe::MeshFunctionGlobal mf_f{ElementMatrixComputation::f};
+  lf::mesh::utils::MeshFunctionGlobal mf_f{ElementMatrixComputation::f};
 
   ElementMatrixComputation::MyLinearLoadVector elvec_builder(
       ElementMatrixComputation::f);
@@ -141,7 +141,7 @@ TEST(MyLinearLoadVector, testQuads)
 {
   auto mesh_p = Generate2DTestMesh();
 
-  lf::uscalfe::MeshFunctionGlobal mf_f{ElementMatrixComputation::f};
+  lf::mesh::utils::MeshFunctionGlobal mf_f{ElementMatrixComputation::f};
 
   ElementMatrixComputation::MyLinearLoadVector elvec_builder(
       ElementMatrixComputation::f);
@@ -169,8 +169,8 @@ TEST(MyLinearFEElementMatrix, testTriangles)
       std::make_shared<lf::uscalfe::FeSpaceLagrangeO1<double>>(mesh_p);
   const lf::mesh::Mesh &mesh{*(fe_space->Mesh())};
 
-  lf::uscalfe::MeshFunctionGlobal mf_alpha{identityMatrixFunctor};
-  lf::uscalfe::MeshFunctionGlobal mf_gamma{identityScalarFunctor};
+  lf::mesh::utils::MeshFunctionGlobal mf_alpha{identityMatrixFunctor};
+  lf::mesh::utils::MeshFunctionGlobal mf_gamma{identityScalarFunctor};
 
   ElementMatrixComputation::MyLinearFEElementMatrix elmat_builder;
   lf::uscalfe::ReactionDiffusionElementMatrixProvider<
@@ -196,8 +196,8 @@ TEST(MyLinearFEElementMatrix, testQuads)
       std::make_shared<lf::uscalfe::FeSpaceLagrangeO1<double>>(mesh_p);
   const lf::mesh::Mesh &mesh{*(fe_space->Mesh())};
 
-  lf::uscalfe::MeshFunctionGlobal mf_alpha{identityMatrixFunctor};
-  lf::uscalfe::MeshFunctionGlobal mf_gamma{identityScalarFunctor};
+  lf::mesh::utils::MeshFunctionGlobal mf_alpha{identityMatrixFunctor};
+  lf::mesh::utils::MeshFunctionGlobal mf_gamma{identityScalarFunctor};
 
   ElementMatrixComputation::MyLinearFEElementMatrix elmat_builder;
   lf::uscalfe::ReactionDiffusionElementMatrixProvider<

--- a/homeworks/ElementMatrixComputation/templates/solve.cc
+++ b/homeworks/ElementMatrixComputation/templates/solve.cc
@@ -22,7 +22,7 @@ namespace ElementMatrixComputation {
 /* SAM_LISTING_BEGIN_2 */
 Eigen::VectorXd solvePoissonBVP() {
   // Convert tPoissonda function f to a LehrFEM++ mesh function object
-  lf::uscalfe::MeshFunctionGlobal mf_f{f};
+  lf::mesh::utils::MeshFunctionGlobal mf_f{f};
 
   // Define the solution vector
   Eigen::VectorXd solution = Eigen::VectorXd::Zero(1);

--- a/homeworks/ElementMatrixComputation/templates/solve.h
+++ b/homeworks/ElementMatrixComputation/templates/solve.h
@@ -83,11 +83,11 @@ Eigen::VectorXd solve(ELMAT_BUILDER &elmat_builder,
   // Postprocessing: Compute and output norms of the finite element solution
   // Helper class for L2 error computation
   lf::uscalfe::MeshFunctionL2NormDifference lc_L2(
-      fe_space, lf::uscalfe::MeshFunctionConstant<double>(0.0), 2);
+      fe_space, lf::mesh::utils::MeshFunctionConstant<double>(0.0), 2);
   // Helper class for H1 semi norm
   lf::uscalfe::MeshFunctionL2GradientDifference lc_H1(
       fe_space,
-      lf::uscalfe::MeshFunctionConstant<Eigen::Vector2d>(
+      lf::mesh::utils::MeshFunctionConstant<Eigen::Vector2d>(
           Eigen::Vector2d(0.0, 0.0)),
       2);
 

--- a/homeworks/ElementMatrixComputation/templates/test/elementeatrixcomputation_test.cc
+++ b/homeworks/ElementMatrixComputation/templates/test/elementeatrixcomputation_test.cc
@@ -53,8 +53,8 @@ TEST(Solve, test) {
   const lf::assemble::DofHandler &dofh{fe_space->LocGlobMap()};
   const lf::base::size_type N_dofs(dofh.NumDofs());
 
-  lf::uscalfe::MeshFunctionGlobal mf_alpha{identityMatrixFunctor};
-  lf::uscalfe::MeshFunctionGlobal mf_gamma{identityScalarFunctor};
+  lf::mesh::utils::MeshFunctionGlobal mf_alpha{identityMatrixFunctor};
+  lf::mesh::utils::MeshFunctionGlobal mf_gamma{identityScalarFunctor};
 
   // Galerkin matrix
   lf::uscalfe::ReactionDiffusionElementMatrixProvider<
@@ -66,7 +66,7 @@ TEST(Solve, test) {
   Eigen::SparseMatrix<double> A_crs = A.makeSparse();
 
   // Right hand side
-  lf::uscalfe::MeshFunctionGlobal mf_f{ElementMatrixComputation::f};
+  lf::mesh::utils::MeshFunctionGlobal mf_f{ElementMatrixComputation::f};
 
   lf::uscalfe::LinearFELocalLoadVector<double, decltype(mf_f)> elvec_builder(
       mf_f);
@@ -91,7 +91,7 @@ TEST(Solve, test) {
 // Test SolvePoissonBVP
 //////////////////////
 TEST(SolvePoissonBVP, test) {
-  lf::uscalfe::MeshFunctionGlobal mf_f{ElementMatrixComputation::f};
+  lf::mesh::utils::MeshFunctionGlobal mf_f{ElementMatrixComputation::f};
 
   lf::uscalfe::LinearFELaplaceElementMatrix elmat_builder;
   lf::uscalfe::LinearFELocalLoadVector<double, decltype(mf_f)> elvec_builder(
@@ -120,7 +120,7 @@ TEST(MyLinearLoadVector, testTriangles)
   std::shared_ptr<lf::mesh::Mesh> mesh_p =
       lf::mesh::test_utils::GenerateHybrid2DTestMesh(0, 1.0 / 3.0);
 
-  lf::uscalfe::MeshFunctionGlobal mf_f{ElementMatrixComputation::f};
+  lf::mesh::utils::MeshFunctionGlobal mf_f{ElementMatrixComputation::f};
 
   ElementMatrixComputation::MyLinearLoadVector elvec_builder(
       ElementMatrixComputation::f);
@@ -141,7 +141,7 @@ TEST(MyLinearLoadVector, testQuads)
 {
   auto mesh_p = Generate2DTestMesh();
 
-  lf::uscalfe::MeshFunctionGlobal mf_f{ElementMatrixComputation::f};
+  lf::mesh::utils::MeshFunctionGlobal mf_f{ElementMatrixComputation::f};
 
   ElementMatrixComputation::MyLinearLoadVector elvec_builder(
       ElementMatrixComputation::f);
@@ -169,8 +169,8 @@ TEST(MyLinearFEElementMatrix, testTriangles)
       std::make_shared<lf::uscalfe::FeSpaceLagrangeO1<double>>(mesh_p);
   const lf::mesh::Mesh &mesh{*(fe_space->Mesh())};
 
-  lf::uscalfe::MeshFunctionGlobal mf_alpha{identityMatrixFunctor};
-  lf::uscalfe::MeshFunctionGlobal mf_gamma{identityScalarFunctor};
+  lf::mesh::utils::MeshFunctionGlobal mf_alpha{identityMatrixFunctor};
+  lf::mesh::utils::MeshFunctionGlobal mf_gamma{identityScalarFunctor};
 
   ElementMatrixComputation::MyLinearFEElementMatrix elmat_builder;
   lf::uscalfe::ReactionDiffusionElementMatrixProvider<
@@ -196,8 +196,8 @@ TEST(MyLinearFEElementMatrix, testQuads)
       std::make_shared<lf::uscalfe::FeSpaceLagrangeO1<double>>(mesh_p);
   const lf::mesh::Mesh &mesh{*(fe_space->Mesh())};
 
-  lf::uscalfe::MeshFunctionGlobal mf_alpha{identityMatrixFunctor};
-  lf::uscalfe::MeshFunctionGlobal mf_gamma{identityScalarFunctor};
+  lf::mesh::utils::MeshFunctionGlobal mf_alpha{identityMatrixFunctor};
+  lf::mesh::utils::MeshFunctionGlobal mf_gamma{identityScalarFunctor};
 
   ElementMatrixComputation::MyLinearFEElementMatrix elmat_builder;
   lf::uscalfe::ReactionDiffusionElementMatrixProvider<

--- a/homeworks/ErrorEstimatesForTraces/mastersolution/tee_lapl_robin_assembly.cc
+++ b/homeworks/ErrorEstimatesForTraces/mastersolution/tee_lapl_robin_assembly.cc
@@ -18,15 +18,15 @@ Eigen::VectorXd solveBVP(
   // Coefficients used in the class template
   // ReactionDiffusionElementMatrixProvider<SCALAR,DIFF_COEFF,REACTION_COEFF>
   auto alpha =
-      lf::uscalfe::MeshFunctionGlobal([](coord_t x) -> double { return 1.0; });
+      lf::mesh::utils::MeshFunctionGlobal([](coord_t x) -> double { return 1.0; });
   auto gamma =
-      lf::uscalfe::MeshFunctionGlobal([](coord_t x) -> double { return 0.0; });
+      lf::mesh::utils::MeshFunctionGlobal([](coord_t x) -> double { return 0.0; });
   // Coefficients used in the class template
   // MassEdgeMatrixProvider< SCALAR, COEFF, EDGESELECTOR >
   auto eta =
-      lf::uscalfe::MeshFunctionGlobal([](coord_t x) -> double { return 1.0; });
+      lf::mesh::utils::MeshFunctionGlobal([](coord_t x) -> double { return 1.0; });
   // Right-hand side source function f
-  auto f = lf::uscalfe::MeshFunctionGlobal(
+  auto f = lf::mesh::utils::MeshFunctionGlobal(
       [](coord_t x) -> double { return std::cos(x.norm()); });
 
   // pointer to current mesh

--- a/homeworks/ErrorEstimatesForTraces/mysolution/tee_lapl_robin_assembly.cc
+++ b/homeworks/ErrorEstimatesForTraces/mysolution/tee_lapl_robin_assembly.cc
@@ -18,15 +18,15 @@ Eigen::VectorXd solveBVP(
   // Coefficients used in the class template
   // ReactionDiffusionElementMatrixProvider<SCALAR,DIFF_COEFF,REACTION_COEFF>
   auto alpha =
-      lf::uscalfe::MeshFunctionGlobal([](coord_t x) -> double { return 1.0; });
+      lf::mesh::utils::MeshFunctionGlobal([](coord_t x) -> double { return 1.0; });
   auto gamma =
-      lf::uscalfe::MeshFunctionGlobal([](coord_t x) -> double { return 0.0; });
+      lf::mesh::utils::MeshFunctionGlobal([](coord_t x) -> double { return 0.0; });
   // Coefficients used in the class template
   // MassEdgeMatrixProvider< SCALAR, COEFF, EDGESELECTOR >
   auto eta =
-      lf::uscalfe::MeshFunctionGlobal([](coord_t x) -> double { return 1.0; });
+      lf::mesh::utils::MeshFunctionGlobal([](coord_t x) -> double { return 1.0; });
   // Right-hand side source function f
-  auto f = lf::uscalfe::MeshFunctionGlobal(
+  auto f = lf::mesh::utils::MeshFunctionGlobal(
       [](coord_t x) -> double { return std::cos(x.norm()); });
 
   // pointer to current mesh

--- a/homeworks/ErrorEstimatesForTraces/templates/tee_lapl_robin_assembly.cc
+++ b/homeworks/ErrorEstimatesForTraces/templates/tee_lapl_robin_assembly.cc
@@ -18,15 +18,15 @@ Eigen::VectorXd solveBVP(
   // Coefficients used in the class template
   // ReactionDiffusionElementMatrixProvider<SCALAR,DIFF_COEFF,REACTION_COEFF>
   auto alpha =
-      lf::uscalfe::MeshFunctionGlobal([](coord_t x) -> double { return 1.0; });
+      lf::mesh::utils::MeshFunctionGlobal([](coord_t x) -> double { return 1.0; });
   auto gamma =
-      lf::uscalfe::MeshFunctionGlobal([](coord_t x) -> double { return 0.0; });
+      lf::mesh::utils::MeshFunctionGlobal([](coord_t x) -> double { return 0.0; });
   // Coefficients used in the class template
   // MassEdgeMatrixProvider< SCALAR, COEFF, EDGESELECTOR >
   auto eta =
-      lf::uscalfe::MeshFunctionGlobal([](coord_t x) -> double { return 1.0; });
+      lf::mesh::utils::MeshFunctionGlobal([](coord_t x) -> double { return 1.0; });
   // Right-hand side source function f
-  auto f = lf::uscalfe::MeshFunctionGlobal(
+  auto f = lf::mesh::utils::MeshFunctionGlobal(
       [](coord_t x) -> double { return std::cos(x.norm()); });
 
   // pointer to current mesh

--- a/homeworks/FiniteVolumeRobin/mastersolution/test/finitevolumerobin_test.cc
+++ b/homeworks/FiniteVolumeRobin/mastersolution/test/finitevolumerobin_test.cc
@@ -29,7 +29,7 @@ TEST(FiniteVolumeRobin, EdgeMatrixProvider) {
   // initialize functors gamma and v
   auto gamma = [](Eigen::Vector2d x) { return 2.0; };
   auto v = [](Eigen::Vector2d x) { return 2 * x(0) + x(1); };
-  auto v_mf = lf::uscalfe::MeshFunctionGlobal(v);
+  auto v_mf = lf::mesh::utils::MeshFunctionGlobal(v);
 
   // set up finite element space and dofhandler
   auto fe_space =

--- a/homeworks/FiniteVolumeRobin/mysolution/test/finitevolumerobin_test.cc
+++ b/homeworks/FiniteVolumeRobin/mysolution/test/finitevolumerobin_test.cc
@@ -29,7 +29,7 @@ TEST(FiniteVolumeRobin, EdgeMatrixProvider) {
   // initialize functors gamma and v
   auto gamma = [](Eigen::Vector2d x) { return 2.0; };
   auto v = [](Eigen::Vector2d x) { return 2 * x(0) + x(1); };
-  auto v_mf = lf::uscalfe::MeshFunctionGlobal(v);
+  auto v_mf = lf::mesh::utils::MeshFunctionGlobal(v);
 
   // set up finite element space and dofhandler
   auto fe_space =

--- a/homeworks/FiniteVolumeRobin/templates/test/finitevolumerobin_test.cc
+++ b/homeworks/FiniteVolumeRobin/templates/test/finitevolumerobin_test.cc
@@ -29,7 +29,7 @@ TEST(FiniteVolumeRobin, EdgeMatrixProvider) {
   // initialize functors gamma and v
   auto gamma = [](Eigen::Vector2d x) { return 2.0; };
   auto v = [](Eigen::Vector2d x) { return 2 * x(0) + x(1); };
-  auto v_mf = lf::uscalfe::MeshFunctionGlobal(v);
+  auto v_mf = lf::mesh::utils::MeshFunctionGlobal(v);
 
   // set up finite element space and dofhandler
   auto fe_space =

--- a/homeworks/HandlingDOFs/mastersolution/test/handling_dofs_test.cc
+++ b/homeworks/HandlingDOFs/mastersolution/test/handling_dofs_test.cc
@@ -36,7 +36,7 @@ std::shared_ptr<const lf::mesh::Mesh> singleTriagMesh()
   nodesOfTria << 0, 1, 0, 0, 0, 1;
   mesh_factory_ptr->AddEntity(
       lf::base::RefEl::kTria(),
-      nonstd::span<const size_type>({0, 1, 2}),
+      std::vector<size_type>({0, 1, 2}),
       std::unique_ptr<lf::geometry::Geometry>(nullptr)); // node coords
 
   std::shared_ptr<const lf::mesh::Mesh> mesh_p = mesh_factory_ptr->Build();

--- a/homeworks/HandlingDOFs/mysolution/test/handling_dofs_test.cc
+++ b/homeworks/HandlingDOFs/mysolution/test/handling_dofs_test.cc
@@ -36,7 +36,7 @@ std::shared_ptr<const lf::mesh::Mesh> singleTriagMesh()
   nodesOfTria << 0, 1, 0, 0, 0, 1;
   mesh_factory_ptr->AddEntity(
       lf::base::RefEl::kTria(),
-      nonstd::span<const size_type>({0, 1, 2}),
+      std::vector<size_type>({0, 1, 2}),
       std::unique_ptr<lf::geometry::Geometry>(nullptr)); // node coords
 
   std::shared_ptr<const lf::mesh::Mesh> mesh_p = mesh_factory_ptr->Build();

--- a/homeworks/HandlingDOFs/templates/test/handling_dofs_test.cc
+++ b/homeworks/HandlingDOFs/templates/test/handling_dofs_test.cc
@@ -36,7 +36,7 @@ std::shared_ptr<const lf::mesh::Mesh> singleTriagMesh()
   nodesOfTria << 0, 1, 0, 0, 0, 1;
   mesh_factory_ptr->AddEntity(
       lf::base::RefEl::kTria(),
-      nonstd::span<const size_type>({0, 1, 2}),
+      std::vector<size_type>({0, 1, 2}),
       std::unique_ptr<lf::geometry::Geometry>(nullptr)); // node coords
 
   std::shared_ptr<const lf::mesh::Mesh> mesh_p = mesh_factory_ptr->Build();

--- a/homeworks/LinFeReactDiff/mastersolution/lin_fe_react_diff.cc
+++ b/homeworks/LinFeReactDiff/mastersolution/lin_fe_react_diff.cc
@@ -39,15 +39,15 @@ Eigen::VectorXd solveFE(std::shared_ptr<const lf::mesh::Mesh> mesh)
     // with Dirichlet boundary conditions fixed to 0.
     // used for the boundary conditions
     auto zero = [](Eigen::Vector2d x) -> double { return 0.; };
-    lf::uscalfe::MeshFunctionGlobal mf_zero{zero};
+    lf::mesh::utils::MeshFunctionGlobal mf_zero{zero};
 
     // used for the Galerkin Matrix
     auto identity = [](Eigen::Vector2d x) -> double { return 1.; };
-    lf::uscalfe::MeshFunctionGlobal mf_identity{identity};
+    lf::mesh::utils::MeshFunctionGlobal mf_identity{identity};
 
     // used for the load vector
     auto c = [](Eigen::Vector2d x) -> double { return x[0] * x[1]; };
-    lf::uscalfe::MeshFunctionGlobal mf_c{c};
+    lf::mesh::utils::MeshFunctionGlobal mf_c{c};
 
     auto fe_space =
         std::make_shared<lf::uscalfe::FeSpaceLagrangeO1<double>>(mesh);
@@ -119,10 +119,10 @@ double computeEnergy(std::shared_ptr<const lf::mesh::Mesh> mesh,
     const lf::base::size_type N_dofs(dofh.NumDofs());
 
     auto identity = [](Eigen::Vector2d x) -> double { return 1.; };
-    lf::uscalfe::MeshFunctionGlobal mf_identity{identity};
+    lf::mesh::utils::MeshFunctionGlobal mf_identity{identity};
 
     auto zero = [](Eigen::Vector2d x) -> double { return 0.; };
-    lf::uscalfe::MeshFunctionGlobal mf_zero{zero};
+    lf::mesh::utils::MeshFunctionGlobal mf_zero{zero};
 
     // Matrix in triplet format holding Stiffness matrix.
     lf::assemble::COOMatrix<double> Stiffness(N_dofs, N_dofs);

--- a/homeworks/LinFeReactDiff/mastersolution/test/lin_fe_react_diff_test.cc
+++ b/homeworks/LinFeReactDiff/mastersolution/test/lin_fe_react_diff_test.cc
@@ -33,11 +33,11 @@ TEST(LinFeReactDiff, TestEnergy)
 
   // Implementation from solution to not depend on the first task
   auto zero = [](Eigen::Vector2d x) -> double { return 0.; };
-  lf::uscalfe::MeshFunctionGlobal mf_zero{zero};
+  lf::mesh::utils::MeshFunctionGlobal mf_zero{zero};
   auto identity = [](Eigen::Vector2d x) -> double { return 1.; };
-  lf::uscalfe::MeshFunctionGlobal mf_identity{identity};
+  lf::mesh::utils::MeshFunctionGlobal mf_identity{identity};
   auto c = [](Eigen::Vector2d x) -> double { return x[0] * x[1]; };
-  lf::uscalfe::MeshFunctionGlobal mf_c{c};
+  lf::mesh::utils::MeshFunctionGlobal mf_c{c};
 
   auto fe_space =
       std::make_shared<lf::uscalfe::FeSpaceLagrangeO1<double>>(mesh);

--- a/homeworks/LinFeReactDiff/mysolution/lin_fe_react_diff.cc
+++ b/homeworks/LinFeReactDiff/mysolution/lin_fe_react_diff.cc
@@ -39,15 +39,15 @@ Eigen::VectorXd solveFE(std::shared_ptr<const lf::mesh::Mesh> mesh)
     // with Dirichlet boundary conditions fixed to 0.
     // used for the boundary conditions
     auto zero = [](Eigen::Vector2d x) -> double { return 0.; };
-    lf::uscalfe::MeshFunctionGlobal mf_zero{zero};
+    lf::mesh::utils::MeshFunctionGlobal mf_zero{zero};
 
     // used for the Galerkin Matrix
     auto identity = [](Eigen::Vector2d x) -> double { return 1.; };
-    lf::uscalfe::MeshFunctionGlobal mf_identity{identity};
+    lf::mesh::utils::MeshFunctionGlobal mf_identity{identity};
 
     // used for the load vector
     auto c = [](Eigen::Vector2d x) -> double { return x[0] * x[1]; };
-    lf::uscalfe::MeshFunctionGlobal mf_c{c};
+    lf::mesh::utils::MeshFunctionGlobal mf_c{c};
 
     auto fe_space =
         std::make_shared<lf::uscalfe::FeSpaceLagrangeO1<double>>(mesh);
@@ -118,10 +118,10 @@ double computeEnergy(std::shared_ptr<const lf::mesh::Mesh> mesh,
     const lf::base::size_type N_dofs(dofh.NumDofs());
 
     auto identity = [](Eigen::Vector2d x) -> double { return 1.; };
-    lf::uscalfe::MeshFunctionGlobal mf_identity{identity};
+    lf::mesh::utils::MeshFunctionGlobal mf_identity{identity};
 
     auto zero = [](Eigen::Vector2d x) -> double { return 0.; };
-    lf::uscalfe::MeshFunctionGlobal mf_zero{zero};
+    lf::mesh::utils::MeshFunctionGlobal mf_zero{zero};
 
     // Matrix in triplet format holding Stiffness matrix.
     lf::assemble::COOMatrix<double> Stiffness(N_dofs, N_dofs);

--- a/homeworks/LinFeReactDiff/mysolution/test/lin_fe_react_diff_test.cc
+++ b/homeworks/LinFeReactDiff/mysolution/test/lin_fe_react_diff_test.cc
@@ -33,11 +33,11 @@ TEST(LinFeReactDiff, TestEnergy)
 
   // Implementation from solution to not depend on the first task
   auto zero = [](Eigen::Vector2d x) -> double { return 0.; };
-  lf::uscalfe::MeshFunctionGlobal mf_zero{zero};
+  lf::mesh::utils::MeshFunctionGlobal mf_zero{zero};
   auto identity = [](Eigen::Vector2d x) -> double { return 1.; };
-  lf::uscalfe::MeshFunctionGlobal mf_identity{identity};
+  lf::mesh::utils::MeshFunctionGlobal mf_identity{identity};
   auto c = [](Eigen::Vector2d x) -> double { return x[0] * x[1]; };
-  lf::uscalfe::MeshFunctionGlobal mf_c{c};
+  lf::mesh::utils::MeshFunctionGlobal mf_c{c};
 
   auto fe_space =
       std::make_shared<lf::uscalfe::FeSpaceLagrangeO1<double>>(mesh);

--- a/homeworks/LinFeReactDiff/templates/lin_fe_react_diff.cc
+++ b/homeworks/LinFeReactDiff/templates/lin_fe_react_diff.cc
@@ -39,15 +39,15 @@ Eigen::VectorXd solveFE(std::shared_ptr<const lf::mesh::Mesh> mesh)
     // with Dirichlet boundary conditions fixed to 0.
     // used for the boundary conditions
     auto zero = [](Eigen::Vector2d x) -> double { return 0.; };
-    lf::uscalfe::MeshFunctionGlobal mf_zero{zero};
+    lf::mesh::utils::MeshFunctionGlobal mf_zero{zero};
 
     // used for the Galerkin Matrix
     auto identity = [](Eigen::Vector2d x) -> double { return 1.; };
-    lf::uscalfe::MeshFunctionGlobal mf_identity{identity};
+    lf::mesh::utils::MeshFunctionGlobal mf_identity{identity};
 
     // used for the load vector
     auto c = [](Eigen::Vector2d x) -> double { return x[0] * x[1]; };
-    lf::uscalfe::MeshFunctionGlobal mf_c{c};
+    lf::mesh::utils::MeshFunctionGlobal mf_c{c};
 
     auto fe_space =
         std::make_shared<lf::uscalfe::FeSpaceLagrangeO1<double>>(mesh);
@@ -118,10 +118,10 @@ double computeEnergy(std::shared_ptr<const lf::mesh::Mesh> mesh,
     const lf::base::size_type N_dofs(dofh.NumDofs());
 
     auto identity = [](Eigen::Vector2d x) -> double { return 1.; };
-    lf::uscalfe::MeshFunctionGlobal mf_identity{identity};
+    lf::mesh::utils::MeshFunctionGlobal mf_identity{identity};
 
     auto zero = [](Eigen::Vector2d x) -> double { return 0.; };
-    lf::uscalfe::MeshFunctionGlobal mf_zero{zero};
+    lf::mesh::utils::MeshFunctionGlobal mf_zero{zero};
 
     // Matrix in triplet format holding Stiffness matrix.
     lf::assemble::COOMatrix<double> Stiffness(N_dofs, N_dofs);

--- a/homeworks/LinFeReactDiff/templates/test/lin_fe_react_diff_test.cc
+++ b/homeworks/LinFeReactDiff/templates/test/lin_fe_react_diff_test.cc
@@ -33,11 +33,11 @@ TEST(LinFeReactDiff, TestEnergy)
 
   // Implementation from solution to not depend on the first task
   auto zero = [](Eigen::Vector2d x) -> double { return 0.; };
-  lf::uscalfe::MeshFunctionGlobal mf_zero{zero};
+  lf::mesh::utils::MeshFunctionGlobal mf_zero{zero};
   auto identity = [](Eigen::Vector2d x) -> double { return 1.; };
-  lf::uscalfe::MeshFunctionGlobal mf_identity{identity};
+  lf::mesh::utils::MeshFunctionGlobal mf_identity{identity};
   auto c = [](Eigen::Vector2d x) -> double { return x[0] * x[1]; };
-  lf::uscalfe::MeshFunctionGlobal mf_c{c};
+  lf::mesh::utils::MeshFunctionGlobal mf_c{c};
 
   auto fe_space =
       std::make_shared<lf::uscalfe::FeSpaceLagrangeO1<double>>(mesh);

--- a/homeworks/NonConformingCrouzeixRaviartFiniteElements/mastersolution/solve_cr_dirichlet_bvp.h
+++ b/homeworks/NonConformingCrouzeixRaviartFiniteElements/mastersolution/solve_cr_dirichlet_bvp.h
@@ -26,10 +26,10 @@ Eigen::VectorXd solveCRDirichletBVP(std::shared_ptr<CRFeSpace> fe_space,
     const size_type num_dofs = dof_handler.NumDofs();
 
     // Prepare coefficient and source functions as MeshFunction
-    lf::uscalfe::MeshFunctionGlobal mf_one{
+    lf::mesh::utils::MeshFunctionGlobal mf_one{
         [](Eigen::Vector2d x) -> double { return 1.; }};
-    lf::uscalfe::MeshFunctionGlobal mf_gamma{gamma};
-    lf::uscalfe::MeshFunctionGlobal mf_f{f};
+    lf::mesh::utils::MeshFunctionGlobal mf_gamma{gamma};
+    lf::mesh::utils::MeshFunctionGlobal mf_f{f};
     // Sparse Galerkin matrix in triplet format
     lf::assemble::COOMatrix<scalar_type> A(num_dofs, num_dofs);
     // Initialize ELEMENT_MATRIX_PROVIDER object

--- a/homeworks/NonConformingCrouzeixRaviartFiniteElements/mastersolution/solve_cr_neumann_bvp.h
+++ b/homeworks/NonConformingCrouzeixRaviartFiniteElements/mastersolution/solve_cr_neumann_bvp.h
@@ -26,10 +26,10 @@ Eigen::VectorXd solveCRNeumannBVP(std::shared_ptr<CRFeSpace> fe_space,
     const lf::assemble::DofHandler &dof_handler{fe_space->LocGlobMap()};
     const size_type num_dofs = dof_handler.NumDofs();
     // Prepare coefficient and source functions as MeshFunction
-    lf::uscalfe::MeshFunctionGlobal mf_one{
+    lf::mesh::utils::MeshFunctionGlobal mf_one{
         [](Eigen::Vector2d x) -> double { return 1.; }};
-    lf::uscalfe::MeshFunctionGlobal mf_gamma{gamma};
-    lf::uscalfe::MeshFunctionGlobal mf_f{f};
+    lf::mesh::utils::MeshFunctionGlobal mf_gamma{gamma};
+    lf::mesh::utils::MeshFunctionGlobal mf_f{f};
     // Sparse Galerkin matrix in triplet format
     lf::assemble::COOMatrix<scalar_type> A(num_dofs, num_dofs);
     // Initialize ELEMENT_MATRIX_PROVIDER object

--- a/homeworks/OutputImpedanceBVP/mastersolution/OutputImpedanceBVP.cc
+++ b/homeworks/OutputImpedanceBVP/mastersolution/OutputImpedanceBVP.cc
@@ -82,7 +82,7 @@ Eigen::VectorXd solveImpedanceBVP(
   // Coefficients used in the class template
   // MassEdgeMatrixProvider< SCALAR, COEFF, EDGESELECTOR >
   auto eta =
-      lf::uscalfe::MeshFunctionGlobal([](coord_t x) -> double { return 1.0; });
+      lf::mesh::utils::MeshFunctionGlobal([](coord_t x) -> double { return 1.0; });
   lf::uscalfe::MassEdgeMatrixProvider<double, decltype(eta),
                                       decltype(edges_predicate_RobinBC)>
       edgemat_builder(fe_space_p, eta, edges_predicate_RobinBC);
@@ -94,7 +94,7 @@ Eigen::VectorXd solveImpedanceBVP(
   // I.iii : Computing right-hand side vector
   // Right-hand side source function f
   auto mf_f =
-      lf::uscalfe::MeshFunctionGlobal([](coord_t x) -> double { return 0.0; });
+      lf::mesh::utils::MeshFunctionGlobal([](coord_t x) -> double { return 0.0; });
   lf::uscalfe::ScalarLoadElementVectorProvider<double, decltype(mf_f)>
       elvec_builder(fe_space_p, mf_f);
   // Invoke assembly on cells (codim == 0)
@@ -102,7 +102,7 @@ Eigen::VectorXd solveImpedanceBVP(
 
   // I.iv : Imposing essential boundary conditions
   // Dirichlet data
-  auto mf_g = lf::uscalfe::MeshFunctionGlobal(
+  auto mf_g = lf::mesh::utils::MeshFunctionGlobal(
       [&g](coord_t x) -> double { return g.dot(x); });
   // Inspired by the example in the documentation of
   // InitEssentialConditionFromFunction()

--- a/homeworks/OutputImpedanceBVP/mastersolution/OutputImpedanceBVP.h
+++ b/homeworks/OutputImpedanceBVP/mastersolution/OutputImpedanceBVP.h
@@ -42,7 +42,7 @@ Eigen::VectorXd interpolateData(
     FUNCTOR_U &&u) {
 
   // Generate Lehrfem++ mesh functions out of the functors
-  auto mf_u = lf::uscalfe::MeshFunctionGlobal(
+  auto mf_u = lf::mesh::utils::MeshFunctionGlobal(
       [&u](coord_t x) -> double { return u(x); });
 
   Eigen::VectorXd dof_vector_u = lf::uscalfe::NodalProjection(*fe_space_p, mf_u);

--- a/homeworks/OutputImpedanceBVP/mysolution/OutputImpedanceBVP.cc
+++ b/homeworks/OutputImpedanceBVP/mysolution/OutputImpedanceBVP.cc
@@ -68,7 +68,7 @@ Eigen::VectorXd solveImpedanceBVP(
   // I.iii : Computing right-hand side vector
   // Right-hand side source function f
   auto mf_f =
-      lf::uscalfe::MeshFunctionGlobal([](coord_t x) -> double { return 0.0; });
+      lf::mesh::utils::MeshFunctionGlobal([](coord_t x) -> double { return 0.0; });
   lf::uscalfe::ScalarLoadElementVectorProvider<double, decltype(mf_f)>
       elvec_builder(fe_space_p, mf_f);
   // Invoke assembly on cells (codim == 0)
@@ -76,7 +76,7 @@ Eigen::VectorXd solveImpedanceBVP(
 
   // I.iv : Imposing essential boundary conditions
   // Dirichlet data
-  auto mf_g = lf::uscalfe::MeshFunctionGlobal(
+  auto mf_g = lf::mesh::utils::MeshFunctionGlobal(
       [&g](coord_t x) -> double { return g.dot(x); });
   //====================
   // Your code goes here

--- a/homeworks/OutputImpedanceBVP/mysolution/OutputImpedanceBVP.h
+++ b/homeworks/OutputImpedanceBVP/mysolution/OutputImpedanceBVP.h
@@ -42,7 +42,7 @@ Eigen::VectorXd interpolateData(
     FUNCTOR_U &&u) {
 
   // Generate Lehrfem++ mesh functions out of the functors
-  auto mf_u = lf::uscalfe::MeshFunctionGlobal(
+  auto mf_u = lf::mesh::utils::MeshFunctionGlobal(
       [&u](coord_t x) -> double { return u(x); });
 
   Eigen::VectorXd dof_vector_u = lf::uscalfe::NodalProjection(*fe_space_p, mf_u);

--- a/homeworks/OutputImpedanceBVP/templates/OutputImpedanceBVP.cc
+++ b/homeworks/OutputImpedanceBVP/templates/OutputImpedanceBVP.cc
@@ -68,7 +68,7 @@ Eigen::VectorXd solveImpedanceBVP(
   // I.iii : Computing right-hand side vector
   // Right-hand side source function f
   auto mf_f =
-      lf::uscalfe::MeshFunctionGlobal([](coord_t x) -> double { return 0.0; });
+      lf::mesh::utils::MeshFunctionGlobal([](coord_t x) -> double { return 0.0; });
   lf::uscalfe::ScalarLoadElementVectorProvider<double, decltype(mf_f)>
       elvec_builder(fe_space_p, mf_f);
   // Invoke assembly on cells (codim == 0)
@@ -76,7 +76,7 @@ Eigen::VectorXd solveImpedanceBVP(
 
   // I.iv : Imposing essential boundary conditions
   // Dirichlet data
-  auto mf_g = lf::uscalfe::MeshFunctionGlobal(
+  auto mf_g = lf::mesh::utils::MeshFunctionGlobal(
       [&g](coord_t x) -> double { return g.dot(x); });
   //====================
   // Your code goes here

--- a/homeworks/OutputImpedanceBVP/templates/OutputImpedanceBVP.h
+++ b/homeworks/OutputImpedanceBVP/templates/OutputImpedanceBVP.h
@@ -42,7 +42,7 @@ Eigen::VectorXd interpolateData(
     FUNCTOR_U &&u) {
 
   // Generate Lehrfem++ mesh functions out of the functors
-  auto mf_u = lf::uscalfe::MeshFunctionGlobal(
+  auto mf_u = lf::mesh::utils::MeshFunctionGlobal(
       [&u](coord_t x) -> double { return u(x); });
 
   Eigen::VectorXd dof_vector_u = lf::uscalfe::NodalProjection(*fe_space_p, mf_u);

--- a/homeworks/ParametricElementMatrices/mastersolution/parametricelementmatrices_main.cc
+++ b/homeworks/ParametricElementMatrices/mastersolution/parametricelementmatrices_main.cc
@@ -34,7 +34,7 @@ int main() {
   /* GENERATE BVP DATA */
   // Interpolate variable coefficient function w(x) = sin(|x|)
   auto w_func = [](Eigen::Vector2d x) -> double { return std::sin(x.norm()); };
-  lf::uscalfe::MeshFunctionGlobal mf_w_func{w_func};
+  lf::mesh::utils::MeshFunctionGlobal mf_w_func{w_func};
   auto w = lf::uscalfe::NodalProjection<double>(*fe_space, mf_w_func);
   // Create direction vector entering the anisotropic diffusion tensor
   auto d = [](Eigen::Vector2d x) -> Eigen::Vector2d { return x; };

--- a/homeworks/ParametricElementMatrices/mastersolution/test/parametric_element_matrices_test.cc
+++ b/homeworks/ParametricElementMatrices/mastersolution/test/parametric_element_matrices_test.cc
@@ -30,9 +30,9 @@ TEST(ParametricElementMatrices, TestGalerkin)
     const Eigen::Vector2d d_x{d(x)};
     return Eigen::Matrix2d::Identity(2, 2) + d_x * d_x.transpose();
   };
-  lf::uscalfe::MeshFunctionGlobal mf_alpha{alpha};
+  lf::mesh::utils::MeshFunctionGlobal mf_alpha{alpha};
   auto zero = [](Eigen::Vector2d x) -> double { return 0.; };
-  lf::uscalfe::MeshFunctionGlobal mf_zero{zero};
+  lf::mesh::utils::MeshFunctionGlobal mf_zero{zero};
   // set up quadrature rule to be able to compare
   std::map<lf::base::RefEl, lf::quad::QuadRule> quad_rules{
       {lf::base::RefEl::kTria(), lf::quad::make_TriaQR_EdgeMidpointRule()},
@@ -68,12 +68,12 @@ TEST(ParametricElementMatrices, TestLoad)
   // An affine linear function that can be represented exactly
   // in the space of p.w. linear Lagrangian finite element functions
   auto w_func = [](Eigen::Vector2d x) -> double { return (3.0 * x[0] - x[1]); };
-  lf::uscalfe::MeshFunctionGlobal mf_w_func{w_func};
+  lf::mesh::utils::MeshFunctionGlobal mf_w_func{w_func};
   // function f(x) = 1/(1 + w(x)^2)
   auto f = [&w_func](Eigen::Vector2d x) -> double {
     return 1. / (1. + std::pow(w_func(x), 2));
   };
-  lf::uscalfe::MeshFunctionGlobal mf_f{f};
+  lf::mesh::utils::MeshFunctionGlobal mf_f{f};
 
   // interpolation of w on fe space: reproduces function
   auto w = lf::uscalfe::NodalProjection<double>(*fe_space, mf_w_func);

--- a/homeworks/ParametricElementMatrices/mysolution/parametricelementmatrices_main.cc
+++ b/homeworks/ParametricElementMatrices/mysolution/parametricelementmatrices_main.cc
@@ -34,7 +34,7 @@ int main() {
   /* GENERATE BVP DATA */
   // Interpolate variable coefficient function w(x) = sin(|x|)
   auto w_func = [](Eigen::Vector2d x) -> double { return std::sin(x.norm()); };
-  lf::uscalfe::MeshFunctionGlobal mf_w_func{w_func};
+  lf::mesh::utils::MeshFunctionGlobal mf_w_func{w_func};
   auto w = lf::uscalfe::NodalProjection<double>(*fe_space, mf_w_func);
   // Create direction vector entering the anisotropic diffusion tensor
   auto d = [](Eigen::Vector2d x) -> Eigen::Vector2d { return x; };

--- a/homeworks/ParametricElementMatrices/templates/parametricelementmatrices_main.cc
+++ b/homeworks/ParametricElementMatrices/templates/parametricelementmatrices_main.cc
@@ -34,7 +34,7 @@ int main() {
   /* GENERATE BVP DATA */
   // Interpolate variable coefficient function w(x) = sin(|x|)
   auto w_func = [](Eigen::Vector2d x) -> double { return std::sin(x.norm()); };
-  lf::uscalfe::MeshFunctionGlobal mf_w_func{w_func};
+  lf::mesh::utils::MeshFunctionGlobal mf_w_func{w_func};
   auto w = lf::uscalfe::NodalProjection<double>(*fe_space, mf_w_func);
   // Create direction vector entering the anisotropic diffusion tensor
   auto d = [](Eigen::Vector2d x) -> Eigen::Vector2d { return x; };

--- a/homeworks/ProjectionOntoGradients/mastersolution/test/projectionontogradients_test.cc
+++ b/homeworks/ProjectionOntoGradients/mastersolution/test/projectionontogradients_test.cc
@@ -51,7 +51,7 @@ TEST(ProjectionOntoGradients, GradProjRhsProvider_1) {
   // initialize functions f and v for which the linear form is evaluated
   auto f = [](Eigen::Vector2d x) { return Eigen::Vector2d(1.0, 2.0); };
   auto v = [](Eigen::Vector2d x) { return 2 * x(0) + x(1); };
-  auto v_mf = lf::uscalfe::MeshFunctionGlobal(v);
+  auto v_mf = lf::mesh::utils::MeshFunctionGlobal(v);
 
   // set up finite elements
   std::shared_ptr<const lf::uscalfe::UniformScalarFESpace<double>> fe_space =
@@ -81,7 +81,7 @@ TEST(ProjectionOntoGradients, GradProjRhsProvider_2) {
   // initialize functions f and v for which the linear form is evaluated
   auto f = [](Eigen::Vector2d x) { return Eigen::Vector2d(x(1), x(0)); };
   auto v = [](Eigen::Vector2d x) { return 2 * x(0) + x(1); };
-  auto v_mf = lf::uscalfe::MeshFunctionGlobal(v);
+  auto v_mf = lf::mesh::utils::MeshFunctionGlobal(v);
 
   // set up finite elements
   std::shared_ptr<const lf::uscalfe::UniformScalarFESpace<double>> fe_space =
@@ -239,7 +239,7 @@ TEST(ProjectionOntoGradients, exact_sol_test) {
   // The Function lf::uscalfe::NodalProjection requires a mesh function as its
   // second argument, so we first construct a meshFunction object which
   // describes the tent function.
-  auto tentFunction_mf = lf::uscalfe::MeshFunctionGlobal(tentFunction);
+  auto tentFunction_mf = lf::mesh::utils::MeshFunctionGlobal(tentFunction);
   auto ref_vec =
       lf::uscalfe::NodalProjection<double>(fe_space, tentFunction_mf);
 

--- a/homeworks/ProjectionOntoGradients/mysolution/test/projectionontogradients_test.cc
+++ b/homeworks/ProjectionOntoGradients/mysolution/test/projectionontogradients_test.cc
@@ -51,7 +51,7 @@ TEST(ProjectionOntoGradients, GradProjRhsProvider_1) {
   // initialize functions f and v for which the linear form is evaluated
   auto f = [](Eigen::Vector2d x) { return Eigen::Vector2d(1.0, 2.0); };
   auto v = [](Eigen::Vector2d x) { return 2 * x(0) + x(1); };
-  auto v_mf = lf::uscalfe::MeshFunctionGlobal(v);
+  auto v_mf = lf::mesh::utils::MeshFunctionGlobal(v);
 
   // set up finite elements
   std::shared_ptr<const lf::uscalfe::UniformScalarFESpace<double>> fe_space =
@@ -81,7 +81,7 @@ TEST(ProjectionOntoGradients, GradProjRhsProvider_2) {
   // initialize functions f and v for which the linear form is evaluated
   auto f = [](Eigen::Vector2d x) { return Eigen::Vector2d(x(1), x(0)); };
   auto v = [](Eigen::Vector2d x) { return 2 * x(0) + x(1); };
-  auto v_mf = lf::uscalfe::MeshFunctionGlobal(v);
+  auto v_mf = lf::mesh::utils::MeshFunctionGlobal(v);
 
   // set up finite elements
   std::shared_ptr<const lf::uscalfe::UniformScalarFESpace<double>> fe_space =

--- a/homeworks/ProjectionOntoGradients/templates/test/projectionontogradients_test.cc
+++ b/homeworks/ProjectionOntoGradients/templates/test/projectionontogradients_test.cc
@@ -51,7 +51,7 @@ TEST(ProjectionOntoGradients, GradProjRhsProvider_1) {
   // initialize functions f and v for which the linear form is evaluated
   auto f = [](Eigen::Vector2d x) { return Eigen::Vector2d(1.0, 2.0); };
   auto v = [](Eigen::Vector2d x) { return 2 * x(0) + x(1); };
-  auto v_mf = lf::uscalfe::MeshFunctionGlobal(v);
+  auto v_mf = lf::mesh::utils::MeshFunctionGlobal(v);
 
   // set up finite elements
   std::shared_ptr<const lf::uscalfe::UniformScalarFESpace<double>> fe_space =
@@ -81,7 +81,7 @@ TEST(ProjectionOntoGradients, GradProjRhsProvider_2) {
   // initialize functions f and v for which the linear form is evaluated
   auto f = [](Eigen::Vector2d x) { return Eigen::Vector2d(x(1), x(0)); };
   auto v = [](Eigen::Vector2d x) { return 2 * x(0) + x(1); };
-  auto v_mf = lf::uscalfe::MeshFunctionGlobal(v);
+  auto v_mf = lf::mesh::utils::MeshFunctionGlobal(v);
 
   // set up finite elements
   std::shared_ptr<const lf::uscalfe::UniformScalarFESpace<double>> fe_space =

--- a/homeworks/RegularizedNeumann/mastersolution/RegularizedNeumann_main.cc
+++ b/homeworks/RegularizedNeumann/mastersolution/RegularizedNeumann_main.cc
@@ -9,9 +9,9 @@
 #include "regNeumann.h"
 
 int main() {
-  const auto f = lf::uscalfe::MeshFunctionGlobal(
+  const auto f = lf::mesh::utils::MeshFunctionGlobal(
       [](Eigen::Vector2d x) -> double { return 1.0; });
-  const auto h = lf::uscalfe::MeshFunctionGlobal(
+  const auto h = lf::mesh::utils::MeshFunctionGlobal(
       [](Eigen::Vector2d x) -> double { return 1.0; });
 
   auto mesh_p = lf::mesh::test_utils::GenerateHybrid2DTestMesh(4, 3.0);

--- a/homeworks/RegularizedNeumann/mastersolution/test/regularizedneumann_test.cc
+++ b/homeworks/RegularizedNeumann/mastersolution/test/regularizedneumann_test.cc
@@ -50,9 +50,9 @@ TEST(RegularizedNeumann, solution_test_dropDof_const) {
   std::remove("test.msh");
 
   // source and boundary functions for testing
-  const auto f = lf::uscalfe::MeshFunctionGlobal(
+  const auto f = lf::mesh::utils::MeshFunctionGlobal(
       [](Eigen::Vector2d x) -> double { return 1.0; });
-  const auto h = lf::uscalfe::MeshFunctionGlobal(
+  const auto h = lf::mesh::utils::MeshFunctionGlobal(
       [](Eigen::Vector2d x) -> double { return 1.0; });
 
   auto fe_space =
@@ -121,9 +121,9 @@ TEST(RegularizedNeumann, solution_test_dropDof_gen) {
   std::remove("test.msh");
 
   // source and boundary functions for testing
-  const auto f = lf::uscalfe::MeshFunctionGlobal(
+  const auto f = lf::mesh::utils::MeshFunctionGlobal(
       [](Eigen::Vector2d x) -> double { return x(0) + x(1); });
-  const auto h = lf::uscalfe::MeshFunctionGlobal(
+  const auto h = lf::mesh::utils::MeshFunctionGlobal(
       [](Eigen::Vector2d x) -> double { return x(0) + x(1); });
 
   auto fe_space =
@@ -192,9 +192,9 @@ TEST(RegularizedNeumann, solution_test_augment_const) {
   std::remove("test.msh");
 
   // source and boundary functions for testing
-  const auto f = lf::uscalfe::MeshFunctionGlobal(
+  const auto f = lf::mesh::utils::MeshFunctionGlobal(
       [](Eigen::Vector2d x) -> double { return 1.0; });
-  const auto h = lf::uscalfe::MeshFunctionGlobal(
+  const auto h = lf::mesh::utils::MeshFunctionGlobal(
       [](Eigen::Vector2d x) -> double { return 1.0; });
 
   auto fe_space =
@@ -266,9 +266,9 @@ TEST(RegularizedNeumann, solution_test_augment_gen) {
   std::remove("test.msh");
 
   // source and boundary functions for testing
-  const auto f = lf::uscalfe::MeshFunctionGlobal(
+  const auto f = lf::mesh::utils::MeshFunctionGlobal(
       [](Eigen::Vector2d x) -> double { return x(0) + x(1); });
-  const auto h = lf::uscalfe::MeshFunctionGlobal(
+  const auto h = lf::mesh::utils::MeshFunctionGlobal(
       [](Eigen::Vector2d x) -> double { return x(0) + x(1); });
 
   auto fe_space =

--- a/homeworks/RegularizedNeumann/mysolution/test/regularizedneumann_test.cc
+++ b/homeworks/RegularizedNeumann/mysolution/test/regularizedneumann_test.cc
@@ -50,9 +50,9 @@ TEST(RegularizedNeumann, solution_test_dropDof_const) {
   std::remove("test.msh");
 
   // source and boundary functions for testing
-  const auto f = lf::uscalfe::MeshFunctionGlobal(
+  const auto f = lf::mesh::utils::MeshFunctionGlobal(
       [](Eigen::Vector2d x) -> double { return 1.0; });
-  const auto h = lf::uscalfe::MeshFunctionGlobal(
+  const auto h = lf::mesh::utils::MeshFunctionGlobal(
       [](Eigen::Vector2d x) -> double { return 1.0; });
 
   auto fe_space =
@@ -121,9 +121,9 @@ TEST(RegularizedNeumann, solution_test_dropDof_gen) {
   std::remove("test.msh");
 
   // source and boundary functions for testing
-  const auto f = lf::uscalfe::MeshFunctionGlobal(
+  const auto f = lf::mesh::utils::MeshFunctionGlobal(
       [](Eigen::Vector2d x) -> double { return x(0) + x(1); });
-  const auto h = lf::uscalfe::MeshFunctionGlobal(
+  const auto h = lf::mesh::utils::MeshFunctionGlobal(
       [](Eigen::Vector2d x) -> double { return x(0) + x(1); });
 
   auto fe_space =
@@ -192,9 +192,9 @@ TEST(RegularizedNeumann, solution_test_augment_const) {
   std::remove("test.msh");
 
   // source and boundary functions for testing
-  const auto f = lf::uscalfe::MeshFunctionGlobal(
+  const auto f = lf::mesh::utils::MeshFunctionGlobal(
       [](Eigen::Vector2d x) -> double { return 1.0; });
-  const auto h = lf::uscalfe::MeshFunctionGlobal(
+  const auto h = lf::mesh::utils::MeshFunctionGlobal(
       [](Eigen::Vector2d x) -> double { return 1.0; });
 
   auto fe_space =
@@ -266,9 +266,9 @@ TEST(RegularizedNeumann, solution_test_augment_gen) {
   std::remove("test.msh");
 
   // source and boundary functions for testing
-  const auto f = lf::uscalfe::MeshFunctionGlobal(
+  const auto f = lf::mesh::utils::MeshFunctionGlobal(
       [](Eigen::Vector2d x) -> double { return x(0) + x(1); });
-  const auto h = lf::uscalfe::MeshFunctionGlobal(
+  const auto h = lf::mesh::utils::MeshFunctionGlobal(
       [](Eigen::Vector2d x) -> double { return x(0) + x(1); });
 
   auto fe_space =

--- a/homeworks/RegularizedNeumann/templates/test/regularizedneumann_test.cc
+++ b/homeworks/RegularizedNeumann/templates/test/regularizedneumann_test.cc
@@ -50,9 +50,9 @@ TEST(RegularizedNeumann, solution_test_dropDof_const) {
   std::remove("test.msh");
 
   // source and boundary functions for testing
-  const auto f = lf::uscalfe::MeshFunctionGlobal(
+  const auto f = lf::mesh::utils::MeshFunctionGlobal(
       [](Eigen::Vector2d x) -> double { return 1.0; });
-  const auto h = lf::uscalfe::MeshFunctionGlobal(
+  const auto h = lf::mesh::utils::MeshFunctionGlobal(
       [](Eigen::Vector2d x) -> double { return 1.0; });
 
   auto fe_space =
@@ -121,9 +121,9 @@ TEST(RegularizedNeumann, solution_test_dropDof_gen) {
   std::remove("test.msh");
 
   // source and boundary functions for testing
-  const auto f = lf::uscalfe::MeshFunctionGlobal(
+  const auto f = lf::mesh::utils::MeshFunctionGlobal(
       [](Eigen::Vector2d x) -> double { return x(0) + x(1); });
-  const auto h = lf::uscalfe::MeshFunctionGlobal(
+  const auto h = lf::mesh::utils::MeshFunctionGlobal(
       [](Eigen::Vector2d x) -> double { return x(0) + x(1); });
 
   auto fe_space =
@@ -192,9 +192,9 @@ TEST(RegularizedNeumann, solution_test_augment_const) {
   std::remove("test.msh");
 
   // source and boundary functions for testing
-  const auto f = lf::uscalfe::MeshFunctionGlobal(
+  const auto f = lf::mesh::utils::MeshFunctionGlobal(
       [](Eigen::Vector2d x) -> double { return 1.0; });
-  const auto h = lf::uscalfe::MeshFunctionGlobal(
+  const auto h = lf::mesh::utils::MeshFunctionGlobal(
       [](Eigen::Vector2d x) -> double { return 1.0; });
 
   auto fe_space =
@@ -266,9 +266,9 @@ TEST(RegularizedNeumann, solution_test_augment_gen) {
   std::remove("test.msh");
 
   // source and boundary functions for testing
-  const auto f = lf::uscalfe::MeshFunctionGlobal(
+  const auto f = lf::mesh::utils::MeshFunctionGlobal(
       [](Eigen::Vector2d x) -> double { return x(0) + x(1); });
-  const auto h = lf::uscalfe::MeshFunctionGlobal(
+  const auto h = lf::mesh::utils::MeshFunctionGlobal(
       [](Eigen::Vector2d x) -> double { return x(0) + x(1); });
 
   auto fe_space =

--- a/homeworks/SymplecticTimesteppingWaves/mastersolution/symplectictimesteppingwaves_assemble.h
+++ b/homeworks/SymplecticTimesteppingWaves/mastersolution/symplectictimesteppingwaves_assemble.h
@@ -47,11 +47,11 @@ Eigen::SparseMatrix<double> assembleGalerkinMatrix(
   /* Creating coefficient-functions as Lehrfem++ mesh functions */
   // Coefficient-functions used in the class template
   // ReactionDiffusionElementMatrixProvider<SCALAR,DIFF_COEFF,REACTION_COEFF>
-  auto alpha_mf = lf::uscalfe::MeshFunctionGlobal(alpha);
-  auto gamma_mf = lf::uscalfe::MeshFunctionGlobal(gamma);
+  auto alpha_mf = lf::mesh::utils::MeshFunctionGlobal(alpha);
+  auto gamma_mf = lf::mesh::utils::MeshFunctionGlobal(gamma);
   // Coefficient-function used in the class template
   // MassEdgeMatrixProvider< SCALAR, COEFF, EDGESELECTOR >
-  auto beta_mf = lf::uscalfe::MeshFunctionGlobal(beta);
+  auto beta_mf = lf::mesh::utils::MeshFunctionGlobal(beta);
 
   /* Retrieving FE data */
   // pointer to current mesh

--- a/homeworks/UnstableBVP/mastersolution/unstablebvp.cc
+++ b/homeworks/UnstableBVP/mastersolution/unstablebvp.cc
@@ -82,7 +82,7 @@ double solveTemperatureDistribution(
     return x[1] <= 0 ? 1 - x[1] : 0;
   };
   // Wrap into a MeshFunction
-  lf::uscalfe::MeshFunctionGlobal mf_bc{bc};
+  lf::mesh::utils::MeshFunctionGlobal mf_bc{bc};
 
   // We use lowest-order (p.w. linear Lagrangian finite elements), for which
   // LehrFEM++ provides a built-in description according to the paradigm of
@@ -175,7 +175,7 @@ double solveTemperatureDistribution(
   // We use this trick to avoid the manual computation and make use of the
   // LehrFEM facilities :)
   lf::uscalfe::MeshFunctionL2GradientDifference loc_comp(
-      fe_space, lf::uscalfe::MeshFunctionConstant(Eigen::Vector2d(0.0, 0.0)),
+      fe_space, lf::mesh::utils::MeshFunctionConstant(Eigen::Vector2d(0.0, 0.0)),
       2);
 
   // Compute the norm of the ``difference'' (i.e. the norm of the gradient of

--- a/homeworks/UnstableBVP/mastersolution/unstablebvp.cc
+++ b/homeworks/UnstableBVP/mastersolution/unstablebvp.cc
@@ -53,7 +53,7 @@ std::shared_ptr<lf::refinement::MeshHierarchy> createMeshHierarchy(
 
   // Initialize triangle
   mesh_factory_ptr->AddEntity(lf::base::RefEl::kTria(),
-                              nonstd::span<const lf::base::size_type>({0, 1, 2}),
+                              std::vector<lf::base::size_type>({0, 1, 2}),
                               std::unique_ptr<lf::geometry::Geometry>(nullptr));
 
   // Get a pointer to the mesh

--- a/homeworks/UnstableBVP/mysolution/unstablebvp.cc
+++ b/homeworks/UnstableBVP/mysolution/unstablebvp.cc
@@ -82,7 +82,7 @@ double solveTemperatureDistribution(
     return x[1] <= 0 ? 1 - x[1] : 0;
   };
   // Wrap into a MeshFunction
-  lf::uscalfe::MeshFunctionGlobal mf_bc{bc};
+  lf::mesh::utils::MeshFunctionGlobal mf_bc{bc};
 
   // We use lowest-order (p.w. linear Lagrangian finite elements), for which
   // LehrFEM++ provides a built-in description according to the paradigm of
@@ -175,7 +175,7 @@ double solveTemperatureDistribution(
   // We use this trick to avoid the manual computation and make use of the
   // LehrFEM facilities :)
   lf::uscalfe::MeshFunctionL2GradientDifference loc_comp(
-      fe_space, lf::uscalfe::MeshFunctionConstant(Eigen::Vector2d(0.0, 0.0)),
+      fe_space, lf::mesh::utils::MeshFunctionConstant(Eigen::Vector2d(0.0, 0.0)),
       2);
 
   // Compute the norm of the ``difference'' (i.e. the norm of the gradient of

--- a/homeworks/UnstableBVP/mysolution/unstablebvp.cc
+++ b/homeworks/UnstableBVP/mysolution/unstablebvp.cc
@@ -53,7 +53,7 @@ std::shared_ptr<lf::refinement::MeshHierarchy> createMeshHierarchy(
 
   // Initialize triangle
   mesh_factory_ptr->AddEntity(lf::base::RefEl::kTria(),
-                              nonstd::span<const lf::base::size_type>({0, 1, 2}),
+                              std::vector<lf::base::size_type>({0, 1, 2}),
                               std::unique_ptr<lf::geometry::Geometry>(nullptr));
 
   // Get a pointer to the mesh

--- a/homeworks/UnstableBVP/templates/unstablebvp.cc
+++ b/homeworks/UnstableBVP/templates/unstablebvp.cc
@@ -53,7 +53,7 @@ std::shared_ptr<lf::refinement::MeshHierarchy> createMeshHierarchy(
 
   // Initialize triangle
   mesh_factory_ptr->AddEntity(lf::base::RefEl::kTria(),
-                              nonstd::span<const lf::base::size_type>({0, 1, 2}),
+                              std::vector<lf::base::size_type>({0, 1, 2}),
                               std::unique_ptr<lf::geometry::Geometry>(nullptr));
 
   // Get a pointer to the mesh
@@ -82,7 +82,7 @@ double solveTemperatureDistribution(
     return x[1] <= 0 ? 1 - x[1] : 0;
   };
   // Wrap into a MeshFunction
-  lf::uscalfe::MeshFunctionGlobal mf_bc{bc};
+  lf::mesh::utils::MeshFunctionGlobal mf_bc{bc};
 
   // We use lowest-order (p.w. linear Lagrangian finite elements), for which
   // LehrFEM++ provides a built-in description according to the paradigm of
@@ -175,7 +175,7 @@ double solveTemperatureDistribution(
   // We use this trick to avoid the manual computation and make use of the
   // LehrFEM facilities :)
   lf::uscalfe::MeshFunctionL2GradientDifference loc_comp(
-      fe_space, lf::uscalfe::MeshFunctionConstant(Eigen::Vector2d(0.0, 0.0)),
+      fe_space, lf::mesh::utils::MeshFunctionConstant(Eigen::Vector2d(0.0, 0.0)),
       2);
 
   // Compute the norm of the ``difference'' (i.e. the norm of the gradient of


### PR DESCRIPTION
This PR updates the `cmake/Hunter/config.cmake` file so it uses the altest LehrFEM++ version. It also includes some fixes for breaking changes that have happened in LehrFEM++ in the mean time. Now everything compiles with clang 8 and gcc 8.