### PR TITLE
Eval function now has to be implemented in the template

### DIFF
--- a/developers/NitscheMethod/mastersolution/nitschemethod.cc
+++ b/developers/NitscheMethod/mastersolution/nitschemethod.cc
@@ -25,6 +25,12 @@ Eigen::Matrix3d LinearFENitscheElementMatrix::Eval(
     const lf::mesh::Entity &cell) const {
   LF_ASSERT_MSG(cell.RefEl() == lf::base::RefEl::kTria(),
                 "Only implemented for triangles");
+  // The element matrix returned from this function
+  Eigen::Matrix3d el_mat = Eigen::Matrix3d::Zero();
+  // ------------------------------------------------------------------
+  // I: Compute element matrix induced by volume part of bilinear form
+  // ------------------------------------------------------------------
+#if SOLUTION
   // Fetch geometry object for current cell
   const lf::geometry::Geometry &K_geo{*(cell.Geometry())};
   LF_ASSERT_MSG(K_geo.DimGlobal() == 2, "Mesh must be planar");
@@ -35,12 +41,17 @@ Eigen::Matrix3d LinearFENitscheElementMatrix::Eval(
   const Eigen::Matrix2d JinvT(K_geo.JacobianInverseGramian(c_hat_));
   // Transform gradients
   const Eigen::Matrix<double, 2, 3> G = JinvT * G_hat_;
-  // ------------------------------------------------------------------
-  // I: Compute element matrix induced by volume part of bilinear form
   // Element matrix for linear finite elements and the Laplacian
-  Eigen::Matrix3d el_mat(lf::geometry::Volume(K_geo) * G.adjoint() * G);
-  // ------------------------------------------------------------------
+  el_mat = lf::geometry::Volume(K_geo) * G.adjoint() * G;
+#else
+  //====================
+  // Your code goes here
+  //====================
+#endif
+  // ----------------------------------------
   // II: Boundary parts of the bilinear form
+  // ----------------------------------------
+#if SOLUTION
   // Retrieve pointers to all edges of the triangle
   nonstd::span<const lf::mesh::Entity *const> edges{cell.SubEntities(1)};
   LF_ASSERT_MSG(edges.size() == 3, "Triangle must have three edges!");
@@ -71,6 +82,11 @@ Eigen::Matrix3d LinearFENitscheElementMatrix::Eval(
       el_mat(l, l) += fac * 1.0 / 3.0;
     }
   }
+#else
+  //====================
+  // Your code goes here
+  //====================
+#endif
   return el_mat;
 }  // end Eval()
 /* SAM_LISTING_END_5 */


### PR DESCRIPTION
The previous template code for the NitscheMethod problem was already completed. This is now fixed by adding appropriate preprocessor directives to the code.