### PR TITLE
Fix debuggingfem

### DIFF
--- a/developers/DebuggingFEM/mastersolution/debuggingfem_main.cc
+++ b/developers/DebuggingFEM/mastersolution/debuggingfem_main.cc
@@ -105,7 +105,7 @@ int main() {
   const static Eigen::IOFormat CSVFormat(Eigen::FullPrecision,
                                          Eigen::DontAlignCols, ", ", "\n");
   std::ofstream error_file;
-  error_file.open("error.csv");
+  error_file.open(CURRENT_BINARY_DIR "/error.csv");
   error_file << data.format(CSVFormat) << std::endl;
   error_file.close();
   std::cout << "Generated " CURRENT_BINARY_DIR "/error.csv" << std::endl;

--- a/developers/Mehrstellenverfahren/mastersolution/test/mehrstellenverfahren_test.cc
+++ b/developers/Mehrstellenverfahren/mastersolution/test/mehrstellenverfahren_test.cc
@@ -17,10 +17,10 @@ namespace XXX::test {
 
 TEST(XXX, FirstTest) {
   /* Macros available in the Google test framework:
-     EXPECT_EQ(x,y), EXPECT_NE(x,y), EXPECT_LT(x,y), EXPECT_LE(x,y), EXPECT_GT(x,y), EXPECT_GE(x,y)
-     EXPECT_STREQ(x,y), EXPECT_STRNE(x,y) -> for C-strings only !
-     EXPECT_NEAR(x,y,abs_tol) 
-     All testing macros can output a message by a trailing << .... 
+     EXPECT_EQ(x,y), EXPECT_NE(x,y), EXPECT_LT(x,y), EXPECT_LE(x,y),
+     EXPECT_GT(x,y), EXPECT_GE(x,y) EXPECT_STREQ(x,y), EXPECT_STRNE(x,y) -> for
+     C-strings only ! EXPECT_NEAR(x,y,abs_tol) All testing macros can output a
+     message by a trailing << ....
    */
 }
-}
+}  // namespace XXX::test


### PR DESCRIPTION
The output file of the DebuggingFEM exercise was previously stored in the current working directory while the plotting script assumed it to be in the `CURRENT_BINARY_DIR`. This is now fixed.