### PR TITLE
cmake clangd (language server) support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -20,6 +20,9 @@ endif()
 #setup compiler
 set(CMAKE_CXX_STANDARD 17)
 
+# provide cmake project info to clangd (language server)
+set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
+
 #enable warnings
 include(CheckCXXCompilerFlag)
 CHECK_CXX_COMPILER_FLAG(-Wall COMPILER_SUPPORTS_WALL)


### PR DESCRIPTION
This PR enables the following cmake option.

```cmake
set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
```

This provides clangd and possibly other tooling programs with useful
information about the cmake project.
clangd can then understand the project and is able to work.
clangd is a language server which provides the developer with an IDE like experience.
